### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/josesolisrosales/lorenz-attractor/security/code-scanning/1](https://github.com/josesolisrosales/lorenz-attractor/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. The permissions should be set to the minimum required for the job to function correctly. Since the `build` job does not perform any write operations, we can set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
