### PR TITLE
Ignore local superpowers planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ temp/
 tmp/
 *.tmp
 *.temp
+
+# Superpowers planning docs (local only, never committed)
+docs/superpowers/


### PR DESCRIPTION
Adds `docs/superpowers/` to `.gitignore` so brainstorming specs and implementation plans stay local and are never committed.

Direct push to `main` was blocked by the branch-protection rule (changes must go through a PR), so this comes via PR as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)