### PR TITLE
Phase 0: Foundation — polish, honesty & full lint/type cleanup

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -41,9 +41,8 @@ jobs:
 
     - name: Security check with bandit
       run: |
-        bandit -r src/lorenz_attractor/ -f json -o bandit-report.json || true
-        bandit -r src/lorenz_attractor/ || true
+        bandit -r src/lorenz_attractor/ -c pyproject.toml
 
-    - name: Check for vulnerabilities with safety
+    - name: Audit dependencies with pip-audit
       run: |
-        safety check || true
+        pip-audit

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -37,7 +37,11 @@ jobs:
 
     - name: Type check with mypy
       run: |
-        mypy src/lorenz_attractor --strict --ignore-missing-imports
+        # --no-warn-unused-ignores AFTER --strict: numba ships no stubs, so the
+        # `# type: ignore` comments its @jit decorators need are used/unused
+        # depending on the resolved numba/mypy versions. --strict re-enables the
+        # check (overriding pyproject), so disable it here for a stable gate.
+        mypy src/lorenz_attractor --strict --ignore-missing-imports --no-warn-unused-ignores
 
     - name: Security check with bandit
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Lint with flake8
-      run: |
-        # Stop the build if there are Python syntax errors or undefined names
-        flake8 src/lorenz_attractor --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Exit-zero treats all errors as warnings
-        flake8 src/lorenz_attractor --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
-
     - name: Type check with mypy
       run: |
         mypy src/lorenz_attractor --ignore-missing-imports || true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A comprehensive, professional-grade simulation and visualization toolkit for the
 ### Advanced Analysis
 - **Parameter Sweeps**: Automated exploration of parameter space
 - **Bifurcation Analysis**: Comprehensive bifurcation diagram generation
-- **Lyapunov Exponents**: Accurate calculation of system stability measures  
+- **Lyapunov Exponents**: Lyapunov exponent estimation (simplified Benettin method; values are approximate — rigorous re-orthogonalization is planned)
 - **Poincaré Sections**: Phase space cross-sections for detailed analysis
 - **Sensitivity Analysis**: Butterfly effect demonstration and quantification
 
@@ -144,23 +144,22 @@ The package is organized into modular components:
 
 ```
 lorenz_attractor/
-├── core/           # Core simulation engine
-│   ├── lorenz.py   # Lorenz system implementation
-│   ├── simulator.py # Simulation orchestration
-│   └── parameters.py # Parameter management
+├── core/           # System, simulator, parameters
+│   ├── lorenz.py
+│   ├── simulator.py
+│   └── parameters.py
+├── analysis/       # stability.py, sections.py, sweeps.py
 ├── integration/    # Numerical integration methods
 ├── visualization/  # Plotting and real-time graphics
-├── export/         # Data and video export
-├── analysis/       # Advanced analysis tools
-├── web/           # Web interface
-└── utils/         # Utility functions
+├── export/         # Data, image, and video export
+└── web/            # Dash web interface
 ```
 
 ## 🎯 Advanced Features
 
 ### Performance Optimization
 - Numba JIT compilation for critical loops
-- Parallel simulation execution
+- Concurrent (thread-based) simulation execution via `ThreadPoolExecutor` (CPU-bound runs are subject to the GIL; true multi-core speedup requires a process-based approach)
 - Memory-efficient data structures
 - Optimized integration algorithms
 
@@ -177,6 +176,8 @@ lorenz_attractor/
 - Modular analysis components
 
 ## 📈 Performance
+
+> **Indicative only** — measured informally on unspecified hardware; these numbers are not part of CI and may not reflect your environment.
 
 Typical performance on modern hardware:
 - **Basic simulation** (10k points): ~0.1 seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "mypy>=1.5.0",
     "bandit>=1.7.0",
     "safety>=2.0.0",
+    "pip-audit>=2.7.0",
 ]
 gpu = [
     "cupy>=12.0.0",
@@ -90,7 +91,7 @@ profile = "black"
 known_first_party = ["lorenz_attractor"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -114,6 +115,7 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html",
     "--cov-report=xml",
+    "--cov-fail-under=39",
     "--strict-markers",
     "--disable-warnings",
 ]
@@ -121,6 +123,10 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "gpu: marks tests as requiring GPU (deselect with '-m \"not gpu\"')",
 ]
+
+[tool.bandit]
+# B403/B301: pickle is an explicit, opt-in export/import format (export/data.py export_pickle/import_pickle).
+skips = ["B403", "B301"]
 
 [tool.coverage.run]
 source = ["src/lorenz_attractor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
     "flake8>=6.0.0",
     "mypy>=1.5.0",
     "bandit>=1.7.0",
-    "safety>=2.0.0",
     "pip-audit>=2.7.0",
 ]
 gpu = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,11 @@ check_untyped_defs = true
 disallow_untyped_decorators = true
 no_implicit_optional = true
 warn_redundant_casts = true
-# numba ships no type stubs, so the `# type: ignore` comments needed for its
-# untyped @jit decorators are "used" or "unused" depending on the resolved
-# numba/mypy versions. Keeping this true made CI flaky across dependency
-# updates (see the numba ignores in core/lorenz.py, integration/integrators.py).
+# numba ships no type stubs, so the `# type: ignore` comments its untyped @jit
+# decorators need are "used" or "unused" depending on the resolved numba/mypy
+# versions (see core/lorenz.py, integration/integrators.py) — flagging them made
+# CI flaky across dependency updates. NOTE: `--strict` on the CLI re-enables this,
+# so the CI workflow also passes `--no-warn-unused-ignores` after `--strict`.
 warn_unused_ignores = false
 warn_no_return = true
 warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,11 @@ check_untyped_defs = true
 disallow_untyped_decorators = true
 no_implicit_optional = true
 warn_redundant_casts = true
-warn_unused_ignores = true
+# numba ships no type stubs, so the `# type: ignore` comments needed for its
+# untyped @jit decorators are "used" or "unused" depending on the resolved
+# numba/mypy versions. Keeping this true made CI flaky across dependency
+# updates (see the numba ignores in core/lorenz.py, integration/integrators.py).
+warn_unused_ignores = false
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true

--- a/src/lorenz_attractor/analysis/__init__.py
+++ b/src/lorenz_attractor/analysis/__init__.py
@@ -1,6 +1,17 @@
 """Analysis tools for the Lorenz system."""
 
+from . import sweeps
 from .sections import poincare_section
 from .stability import equilibrium_points, jacobian, lyapunov_exponents
+from .sweeps import bifurcation_analysis, parameter_sweep, sensitivity_analysis
 
-__all__ = ['jacobian', 'equilibrium_points', 'lyapunov_exponents', 'poincare_section']
+__all__ = [
+    'jacobian',
+    'equilibrium_points',
+    'lyapunov_exponents',
+    'poincare_section',
+    'sweeps',
+    'parameter_sweep',
+    'bifurcation_analysis',
+    'sensitivity_analysis',
+]

--- a/src/lorenz_attractor/analysis/__init__.py
+++ b/src/lorenz_attractor/analysis/__init__.py
@@ -1,3 +1,5 @@
-"""Advanced analysis components."""
+"""Analysis tools for the Lorenz system."""
 
-pass
+from .stability import equilibrium_points, jacobian, lyapunov_exponents
+
+__all__ = ['jacobian', 'equilibrium_points', 'lyapunov_exponents']

--- a/src/lorenz_attractor/analysis/__init__.py
+++ b/src/lorenz_attractor/analysis/__init__.py
@@ -1,5 +1,6 @@
 """Analysis tools for the Lorenz system."""
 
+from .sections import poincare_section
 from .stability import equilibrium_points, jacobian, lyapunov_exponents
 
-__all__ = ['jacobian', 'equilibrium_points', 'lyapunov_exponents']
+__all__ = ['jacobian', 'equilibrium_points', 'lyapunov_exponents', 'poincare_section']

--- a/src/lorenz_attractor/analysis/__init__.py
+++ b/src/lorenz_attractor/analysis/__init__.py
@@ -1,17 +1,15 @@
-"""Analysis tools for the Lorenz system."""
+"""Analysis tools for the Lorenz system: stability, sections, and sweeps."""
 
-from . import sweeps
 from .sections import poincare_section
 from .stability import equilibrium_points, jacobian, lyapunov_exponents
 from .sweeps import bifurcation_analysis, parameter_sweep, sensitivity_analysis
 
 __all__ = [
-    'jacobian',
-    'equilibrium_points',
-    'lyapunov_exponents',
-    'poincare_section',
-    'sweeps',
-    'parameter_sweep',
-    'bifurcation_analysis',
-    'sensitivity_analysis',
+    "jacobian",
+    "equilibrium_points",
+    "lyapunov_exponents",
+    "poincare_section",
+    "parameter_sweep",
+    "bifurcation_analysis",
+    "sensitivity_analysis",
 ]

--- a/src/lorenz_attractor/analysis/sections.py
+++ b/src/lorenz_attractor/analysis/sections.py
@@ -1,0 +1,31 @@
+"""Poincaré section computation for trajectories."""
+
+from typing import List, Optional
+
+import numpy as np
+
+
+def poincare_section(
+    trajectory: np.ndarray,
+    plane_normal: Optional[np.ndarray] = None,
+    plane_offset: float = 27.0,
+) -> np.ndarray:
+    """Return points where ``trajectory`` crosses the plane n·x = offset.
+
+    Crossings are found by linear interpolation between consecutive samples
+    that lie on opposite sides of the plane.
+    """
+    if plane_normal is None:
+        plane_normal = np.array([0, 0, 1])
+    plane_normal = plane_normal / np.linalg.norm(plane_normal)
+
+    intersections: List[np.ndarray] = []
+    for i in range(len(trajectory) - 1):
+        p1, p2 = trajectory[i], trajectory[i + 1]
+        d1 = np.dot(p1, plane_normal) - plane_offset
+        d2 = np.dot(p2, plane_normal) - plane_offset
+        if d1 * d2 < 0:
+            t = -d1 / (d2 - d1)
+            intersections.append(p1 + t * (p2 - p1))
+
+    return np.array(intersections) if intersections else np.array([]).reshape(0, 3)

--- a/src/lorenz_attractor/analysis/stability.py
+++ b/src/lorenz_attractor/analysis/stability.py
@@ -35,11 +35,7 @@ def jacobian(
 
 def equilibrium_points(system: 'LorenzSystem') -> List[np.ndarray]:
     """Return the equilibrium points: origin always, plus C+/C- when rho > 1."""
-    sigma, rho, beta = (
-        system.parameters.sigma,
-        system.parameters.rho,
-        system.parameters.beta,
-    )
+    rho, beta = system.parameters.rho, system.parameters.beta
     equilibria: List[np.ndarray] = [np.array([0.0, 0.0, 0.0])]
     if rho > 1:
         sqrt_term = np.sqrt(beta * (rho - 1))

--- a/src/lorenz_attractor/analysis/stability.py
+++ b/src/lorenz_attractor/analysis/stability.py
@@ -1,0 +1,83 @@
+"""Stability analysis for the Lorenz system: Jacobian, equilibria, Lyapunov spectrum.
+
+References:
+- Benettin, G. et al. (1980). "Lyapunov characteristic exponents for smooth
+  dynamical systems." Meccanica 15, 9-30.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple, Union
+
+import numpy as np
+
+from ..core.parameters import InitialConditions
+
+if TYPE_CHECKING:
+    from ..core.lorenz import LorenzSystem
+
+
+def jacobian(
+    system: 'LorenzSystem',
+    state: Union[np.ndarray, Tuple[float, float, float]],
+) -> np.ndarray:
+    """Compute the 3x3 Jacobian of the Lorenz system at ``state``."""
+    if isinstance(state, tuple):
+        state = np.array(state)
+    x, y, z = state
+    sigma, rho, beta = (
+        system.parameters.sigma,
+        system.parameters.rho,
+        system.parameters.beta,
+    )
+    return np.array([[-sigma, sigma, 0], [rho - z, -1, -x], [y, x, -beta]])
+
+
+def equilibrium_points(system: 'LorenzSystem') -> List[np.ndarray]:
+    """Return the equilibrium points: origin always, plus C+/C- when rho > 1."""
+    sigma, rho, beta = (
+        system.parameters.sigma,
+        system.parameters.rho,
+        system.parameters.beta,
+    )
+    equilibria: List[np.ndarray] = [np.array([0.0, 0.0, 0.0])]
+    if rho > 1:
+        sqrt_term = np.sqrt(beta * (rho - 1))
+        equilibria.append(np.array([sqrt_term, sqrt_term, rho - 1]))
+        equilibria.append(np.array([-sqrt_term, -sqrt_term, rho - 1]))
+    return equilibria
+
+
+def lyapunov_exponents(
+    system: 'LorenzSystem',
+    initial_conditions: InitialConditions,
+    dt: float = 0.01,
+    num_steps: int = 100000,
+) -> np.ndarray:
+    """Estimate the Lyapunov spectrum via the Benettin tangent-space method."""
+    from scipy.integrate import solve_ivp
+
+    def extended_system(t: float, y: np.ndarray) -> np.ndarray:
+        state = y[:3]
+        tangent_vectors = y[3:].reshape(3, 3)
+        f = system.derivative(state)
+        J = system.jacobian(state)
+        tangent_derivatives = J @ tangent_vectors
+        return np.concatenate([f, tangent_derivatives.flatten()])
+
+    y0 = np.concatenate([initial_conditions.to_array(), np.eye(3).flatten()])
+    t_span = (0, num_steps * dt)
+    t_eval = np.arange(0, num_steps * dt, dt)
+
+    sol = solve_ivp(
+        extended_system, t_span, y0, t_eval=t_eval, method='RK45', rtol=1e-8
+    )
+
+    lyap_sums = np.zeros(3)
+    for i in range(1, len(sol.t)):
+        tangent_matrix = sol.y[3:, i].reshape(3, 3)
+        Q, R = np.linalg.qr(tangent_matrix)
+        lyap_sums += np.log(np.abs(np.diag(R)))
+
+    exponents = lyap_sums / (sol.t[-1])
+    return np.sort(exponents)[::-1]

--- a/src/lorenz_attractor/analysis/sweeps.py
+++ b/src/lorenz_attractor/analysis/sweeps.py
@@ -1,0 +1,107 @@
+"""Parameter sweeps, bifurcation, and sensitivity analysis.
+
+These operate over a Simulator instance so they remain decoupled from any
+specific system and ready to generalize to other dynamical systems later.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ..core.parameters import InitialConditions, LorenzParameters, SimulationConfig
+
+if TYPE_CHECKING:
+    from ..core.simulator import SimulationResult, Simulator
+
+
+def parameter_sweep(
+    simulator: 'Simulator',
+    parameter_name: str,
+    parameter_values: np.ndarray,
+    initial_conditions: InitialConditions,
+    config: SimulationConfig,
+) -> 'List[SimulationResult]':
+    """Run one simulation per parameter value; restore original params after."""
+    original_params = simulator.system.parameters
+    results: List['SimulationResult'] = []
+    for param_value in parameter_values:
+        params_dict = original_params.to_dict()
+        params_dict[parameter_name] = param_value
+        simulator.system.update_parameters(LorenzParameters.from_dict(params_dict))
+        results.append(simulator.simulate(initial_conditions, config))
+    simulator.system.update_parameters(original_params)
+    return results
+
+
+def bifurcation_analysis(
+    simulator: 'Simulator',
+    parameter_name: str,
+    parameter_range: Tuple[float, float],
+    num_points: int = 100,
+    initial_conditions: Optional[InitialConditions] = None,
+    config: Optional[SimulationConfig] = None,
+) -> Dict[str, Any]:
+    """Sweep a parameter and collect the post-transient attractor of each run."""
+    if initial_conditions is None:
+        initial_conditions = InitialConditions.random()
+    if config is None:
+        config = SimulationConfig(num_steps=20000)
+
+    param_min, param_max = parameter_range
+    param_values = np.linspace(param_min, param_max, num_points)
+
+    results = parameter_sweep(
+        simulator, parameter_name, param_values, initial_conditions, config
+    )
+
+    attractors = [result.trajectory[-1000:] for result in results]
+    return {
+        'parameter_values': param_values,
+        'attractors': attractors,
+        'parameter_name': parameter_name,
+    }
+
+
+def sensitivity_analysis(
+    simulator: 'Simulator',
+    initial_conditions: InitialConditions,
+    perturbation: float = 1e-10,
+    config: Optional[SimulationConfig] = None,
+) -> Dict[str, Any]:
+    """Quantify divergence from perturbing each initial coordinate."""
+    if config is None:
+        config = SimulationConfig()
+
+    original_result = simulator.simulate(initial_conditions, config)
+    perturbed_ics = [
+        InitialConditions(
+            initial_conditions.x + perturbation,
+            initial_conditions.y,
+            initial_conditions.z,
+        ),
+        InitialConditions(
+            initial_conditions.x,
+            initial_conditions.y + perturbation,
+            initial_conditions.z,
+        ),
+        InitialConditions(
+            initial_conditions.x,
+            initial_conditions.y,
+            initial_conditions.z + perturbation,
+        ),
+    ]
+    perturbed_results = simulator.simulate_multiple(perturbed_ics, config)
+
+    divergences = [
+        np.linalg.norm(r.trajectory - original_result.trajectory, axis=1)
+        for r in perturbed_results
+    ]
+    return {
+        'original_trajectory': original_result.trajectory,
+        'perturbed_trajectories': [r.trajectory for r in perturbed_results],
+        'divergences': divergences,
+        'time': original_result.time,
+        'perturbation': perturbation,
+    }

--- a/src/lorenz_attractor/analysis/sweeps.py
+++ b/src/lorenz_attractor/analysis/sweeps.py
@@ -22,10 +22,10 @@ def parameter_sweep(
     parameter_values: np.ndarray,
     initial_conditions: InitialConditions,
     config: SimulationConfig,
-) -> 'List[SimulationResult]':
+) -> List[SimulationResult]:
     """Run one simulation per parameter value; restore original params after."""
     original_params = simulator.system.parameters
-    results: List['SimulationResult'] = []
+    results: List[SimulationResult] = []
     for param_value in parameter_values:
         params_dict = original_params.to_dict()
         params_dict[parameter_name] = param_value

--- a/src/lorenz_attractor/cli.py
+++ b/src/lorenz_attractor/cli.py
@@ -287,7 +287,7 @@ def cmd_simulate(args) -> None:
         plotter = LorenzPlotter(style=args.style, dpi=dpi)
 
         if args.plot:
-            fig = plotter.plot_3d_trajectory(
+            plotter.plot_3d_trajectory(
                 result,
                 color_by_time=args.color_by_time,
                 fast_mode=not args.high_quality or args.fast_plot,
@@ -319,7 +319,9 @@ def cmd_realtime(args) -> None:
 
     try:
         if args.method == 'matplotlib':
-            anim = visualizer.start_matplotlib_animation(initial_conditions, config)
+            anim = visualizer.start_matplotlib_animation(  # noqa: F841  # keep ref alive (GC would destroy FuncAnimation before plt.show runs)
+                initial_conditions, config
+            )
             import matplotlib.pyplot as plt
 
             plt.show()
@@ -359,7 +361,7 @@ def cmd_sweep(args) -> None:
         args.parameter, param_values, initial_conditions, config
     )
 
-    print(f"Parameter sweep completed")
+    print("Parameter sweep completed")
 
     # Create plots
     plotter = LorenzPlotter()

--- a/src/lorenz_attractor/cli.py
+++ b/src/lorenz_attractor/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+from typing import Any
 
 import numpy as np
 
@@ -236,7 +237,7 @@ Examples:
     return parser
 
 
-def cmd_simulate(args) -> None:
+def cmd_simulate(args: Any) -> None:
     """Handle simulate command."""
     # Create parameters
     params = LorenzParameters(sigma=args.sigma, rho=args.rho, beta=args.beta)
@@ -276,7 +277,7 @@ def cmd_simulate(args) -> None:
 
     # Export data
     if args.export_data:
-        exporter = DataExporter()
+        exporter = DataExporter()  # type: ignore[no-untyped-call]  # export/data.py is out of this task's scope
         exporter.export_csv(result, args.export_data)
         print(f"Data exported to {args.export_data}")
 
@@ -302,7 +303,7 @@ def cmd_simulate(args) -> None:
             print(f"Video exported to {args.export_video}")
 
 
-def cmd_realtime(args) -> None:
+def cmd_realtime(args: Any) -> None:
     """Handle realtime command."""
     # Create parameters
     params = LorenzParameters(sigma=args.sigma, rho=args.rho, beta=args.beta)
@@ -335,7 +336,7 @@ def cmd_realtime(args) -> None:
         print(f"Error in real-time visualization: {e}")
 
 
-def cmd_sweep(args) -> None:
+def cmd_sweep(args: Any) -> None:
     """Handle parameter sweep command."""
     # Create base parameters
     base_params = LorenzParameters()
@@ -384,7 +385,7 @@ def cmd_sweep(args) -> None:
         print(f"Video exported to {args.export_video}")
 
 
-def cmd_bifurcation(args) -> None:
+def cmd_bifurcation(args: Any) -> None:
     """Handle bifurcation analysis command."""
     # Create parameters
     base_params = LorenzParameters()
@@ -420,7 +421,7 @@ def cmd_bifurcation(args) -> None:
         plt.show()
 
 
-def cmd_analysis(args) -> None:
+def cmd_analysis(args: Any) -> None:
     """Handle advanced analysis command."""
     # Create parameters
     params = LorenzParameters(sigma=args.sigma, rho=args.rho, beta=args.beta)
@@ -480,7 +481,7 @@ def cmd_analysis(args) -> None:
             plt.show()
 
 
-def cmd_web(args) -> None:
+def cmd_web(args: Any) -> None:
     """Handle web interface command."""
     print(f"Starting web interface at http://{args.host}:{args.port}")
     print("Press Ctrl+C to stop the server")

--- a/src/lorenz_attractor/cli.py
+++ b/src/lorenz_attractor/cli.py
@@ -277,7 +277,7 @@ def cmd_simulate(args: Any) -> None:
 
     # Export data
     if args.export_data:
-        exporter = DataExporter()  # type: ignore[no-untyped-call]  # export/data.py is out of this task's scope
+        exporter = DataExporter()
         exporter.export_csv(result, args.export_data)
         print(f"Data exported to {args.export_data}")
 

--- a/src/lorenz_attractor/core/lorenz.py
+++ b/src/lorenz_attractor/core/lorenz.py
@@ -80,19 +80,9 @@ class LorenzSystem:
         Returns:
             3x3 Jacobian matrix
         """
-        if isinstance(state, tuple):
-            state = np.array(state)
+        from ..analysis import stability
 
-        x, y, z = state
-        sigma, rho, beta = (
-            self.parameters.sigma,
-            self.parameters.rho,
-            self.parameters.beta,
-        )
-
-        J = np.array([[-sigma, sigma, 0], [rho - z, -1, -x], [y, x, -beta]])
-
-        return J
+        return stability.jacobian(self, state)
 
     def equilibrium_points(self) -> list:
         """
@@ -101,26 +91,9 @@ class LorenzSystem:
         Returns:
             List of equilibrium points as numpy arrays
         """
-        sigma, rho, beta = (
-            self.parameters.sigma,
-            self.parameters.rho,
-            self.parameters.beta,
-        )
+        from ..analysis import stability
 
-        # Origin is always an equilibrium point
-        equilibria = [np.array([0.0, 0.0, 0.0])]
-
-        # For rho > 1, there are two additional equilibria
-        if rho > 1:
-            sqrt_term = np.sqrt(beta * (rho - 1))
-
-            # C+ equilibrium
-            equilibria.append(np.array([sqrt_term, sqrt_term, rho - 1]))
-
-            # C- equilibrium
-            equilibria.append(np.array([-sqrt_term, -sqrt_term, rho - 1]))
-
-        return equilibria
+        return stability.equilibrium_points(self)
 
     def lyapunov_exponents(
         self,
@@ -139,54 +112,9 @@ class LorenzSystem:
         Returns:
             Array of three Lyapunov exponents
         """
-        # This is a simplified implementation
-        # For production use, consider using more sophisticated methods
+        from ..analysis import stability
 
-        from scipy.integrate import solve_ivp
-
-        def extended_system(t, y):
-            """Extended system for Lyapunov exponent calculation."""
-            state = y[:3]
-            tangent_vectors = y[3:].reshape(3, 3)
-
-            # System derivative
-            f = self.derivative(state)
-
-            # Jacobian
-            J = self.jacobian(state)
-
-            # Tangent vector derivatives
-            tangent_derivatives = J @ tangent_vectors
-
-            return np.concatenate([f, tangent_derivatives.flatten()])
-
-        # Initial conditions: state + identity matrix for tangent vectors
-        y0 = np.concatenate([initial_conditions.to_array(), np.eye(3).flatten()])
-
-        # Integration
-        t_span = (0, num_steps * dt)
-        t_eval = np.arange(0, num_steps * dt, dt)
-
-        sol = solve_ivp(
-            extended_system, t_span, y0, t_eval=t_eval, method='RK45', rtol=1e-8
-        )
-
-        # Extract and orthogonalize tangent vectors
-        lyap_sums = np.zeros(3)
-
-        for i in range(1, len(sol.t)):
-            tangent_matrix = sol.y[3:, i].reshape(3, 3)
-
-            # QR decomposition for orthogonalization
-            Q, R = np.linalg.qr(tangent_matrix)
-
-            # Accumulate logarithms of diagonal elements
-            lyap_sums += np.log(np.abs(np.diag(R)))
-
-        # Calculate average growth rates
-        lyapunov_exponents = lyap_sums / (sol.t[-1])
-
-        return np.sort(lyapunov_exponents)[::-1]  # Sort in descending order
+        return stability.lyapunov_exponents(self, initial_conditions, dt, num_steps)
 
     def poincare_section(
         self,

--- a/src/lorenz_attractor/core/lorenz.py
+++ b/src/lorenz_attractor/core/lorenz.py
@@ -133,24 +133,9 @@ class LorenzSystem:
         Returns:
             Array of intersection points
         """
-        plane_normal = plane_normal / np.linalg.norm(plane_normal)
+        from ..analysis import sections
 
-        intersections = []
-
-        for i in range(len(trajectory) - 1):
-            p1, p2 = trajectory[i], trajectory[i + 1]
-
-            # Check if trajectory crosses the plane
-            d1 = np.dot(p1, plane_normal) - plane_offset
-            d2 = np.dot(p2, plane_normal) - plane_offset
-
-            if d1 * d2 < 0:  # Sign change indicates crossing
-                # Linear interpolation to find intersection
-                t = -d1 / (d2 - d1)
-                intersection = p1 + t * (p2 - p1)
-                intersections.append(intersection)
-
-        return np.array(intersections) if intersections else np.array([]).reshape(0, 3)
+        return sections.poincare_section(trajectory, plane_normal, plane_offset)
 
     def update_parameters(self, new_parameters: LorenzParameters):
         """

--- a/src/lorenz_attractor/core/lorenz.py
+++ b/src/lorenz_attractor/core/lorenz.py
@@ -1,6 +1,6 @@
 """Core Lorenz system implementation with advanced features."""
 
-from typing import Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 from numba import jit
@@ -30,7 +30,7 @@ class LorenzSystem:
         self.parameters = parameters or LorenzParameters.classical()
         self._compiled_derivative = self._compile_derivative()
 
-    def _compile_derivative(self):
+    def _compile_derivative(self) -> Callable[[np.ndarray], np.ndarray]:
         """Compile the derivative function for performance."""
         sigma, rho, beta = (
             self.parameters.sigma,
@@ -38,7 +38,7 @@ class LorenzSystem:
             self.parameters.beta,
         )
 
-        @jit(nopython=True)
+        @jit(nopython=True)  # type: ignore[untyped-decorator]  # numba ships no stubs
         def derivative(state: np.ndarray) -> np.ndarray:
             """Compute derivatives of the Lorenz system."""
             x, y, z = state
@@ -49,7 +49,7 @@ class LorenzSystem:
 
             return np.array([dx_dt, dy_dt, dz_dt])
 
-        return derivative
+        return derivative  # type: ignore[no-any-return]
 
     def derivative(
         self, state: Union[np.ndarray, Tuple[float, float, float]]
@@ -84,7 +84,7 @@ class LorenzSystem:
 
         return stability.jacobian(self, state)
 
-    def equilibrium_points(self) -> list:
+    def equilibrium_points(self) -> List[np.ndarray]:
         """
         Calculate equilibrium points of the system.
 
@@ -137,7 +137,7 @@ class LorenzSystem:
 
         return sections.poincare_section(trajectory, plane_normal, plane_offset)
 
-    def update_parameters(self, new_parameters: LorenzParameters):
+    def update_parameters(self, new_parameters: LorenzParameters) -> None:
         """
         Update system parameters and recompile derivative function.
 

--- a/src/lorenz_attractor/core/parameters.py
+++ b/src/lorenz_attractor/core/parameters.py
@@ -1,7 +1,7 @@
 """Parameter management for Lorenz system simulations."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -14,7 +14,7 @@ class LorenzParameters:
     rho: float = 28.0
     beta: float = 8.0 / 3.0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate parameters after initialization."""
         if self.sigma <= 0:
             raise ValueError("sigma must be positive")
@@ -38,12 +38,12 @@ class LorenzParameters:
         """Returns parameters for fixed point behavior."""
         return cls(sigma=10.0, rho=0.5, beta=8.0 / 3.0)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict[str, float]:
         """Convert parameters to dictionary."""
         return {'sigma': self.sigma, 'rho': self.rho, 'beta': self.beta}
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'LorenzParameters':
+    def from_dict(cls, data: Dict[str, float]) -> 'LorenzParameters':
         """Create parameters from dictionary."""
         return cls(**data)
 
@@ -101,7 +101,7 @@ class SimulationConfig:
     integration_method: str = "rk4"
     save_interval: int = 1
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate configuration after initialization."""
         if self.dt <= 0:
             raise ValueError("dt must be positive")
@@ -124,7 +124,7 @@ class SimulationConfig:
         """Time array for the simulation."""
         return np.arange(0, self.total_time, self.dt)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary."""
         return {
             'dt': self.dt,
@@ -134,6 +134,6 @@ class SimulationConfig:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'SimulationConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SimulationConfig':
         """Create configuration from dictionary."""
         return cls(**data)

--- a/src/lorenz_attractor/core/parameters.py
+++ b/src/lorenz_attractor/core/parameters.py
@@ -110,7 +110,7 @@ class SimulationConfig:
         if self.save_interval <= 0:
             raise ValueError("save_interval must be positive")
 
-        valid_methods = ["euler", "rk4", "rk45", "dopri5"]
+        valid_methods = ["euler", "rk4", "adaptive", "dopri5"]
         if self.integration_method not in valid_methods:
             raise ValueError(f"integration_method must be one of {valid_methods}")
 

--- a/src/lorenz_attractor/core/simulator.py
+++ b/src/lorenz_attractor/core/simulator.py
@@ -283,9 +283,12 @@ class Simulator:
             config = SimulationConfig(num_steps=50000)
 
         # Use system's built-in method
-        return cast(float, self.system.lyapunov_exponents(
-            initial_conditions, config.dt, config.num_steps
-        )[0])
+        return cast(
+            float,
+            self.system.lyapunov_exponents(
+                initial_conditions, config.dt, config.num_steps
+            )[0],
+        )
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/lorenz_attractor/core/simulator.py
+++ b/src/lorenz_attractor/core/simulator.py
@@ -215,7 +215,7 @@ class Simulator:
         num_points: int = 100,
         initial_conditions: InitialConditions = None,
         config: SimulationConfig = None,
-    ) -> Dict[str, np.ndarray]:
+    ) -> Dict[str, Any]:
         """
         Perform bifurcation analysis.
 

--- a/src/lorenz_attractor/core/simulator.py
+++ b/src/lorenz_attractor/core/simulator.py
@@ -13,6 +13,7 @@ from ..integration.integrators import (
     EulerIntegrator,
     RungeKutta4Integrator,
 )
+from ..analysis import sweeps
 from .lorenz import LorenzSystem
 from .parameters import InitialConditions, LorenzParameters, SimulationConfig
 
@@ -203,26 +204,9 @@ class Simulator:
         Returns:
             List of simulation results for each parameter value
         """
-        original_params = self.system.parameters
-        results = []
-
-        for param_value in parameter_values:
-            # Create new parameters
-            params_dict = original_params.to_dict()
-            params_dict[parameter_name] = param_value
-            new_params = LorenzParameters.from_dict(params_dict)
-
-            # Update system
-            self.system.update_parameters(new_params)
-
-            # Simulate
-            result = self.simulate(initial_conditions, config)
-            results.append(result)
-
-        # Restore original parameters
-        self.system.update_parameters(original_params)
-
-        return results
+        return sweeps.parameter_sweep(
+            self, parameter_name, parameter_values, initial_conditions, config
+        )
 
     def bifurcation_analysis(
         self,
@@ -245,33 +229,10 @@ class Simulator:
         Returns:
             Dictionary with parameter values and corresponding attractors
         """
-        if initial_conditions is None:
-            initial_conditions = InitialConditions.random()
-
-        if config is None:
-            config = SimulationConfig(num_steps=20000)
-
-        # Create parameter array
-        param_min, param_max = parameter_range
-        param_values = np.linspace(param_min, param_max, num_points)
-
-        # Run parameter sweep
-        results = self.parameter_sweep(
-            parameter_name, param_values, initial_conditions, config
+        return sweeps.bifurcation_analysis(
+            self, parameter_name, parameter_range, num_points,
+            initial_conditions, config,
         )
-
-        # Extract attractor points (last 1000 points of each simulation)
-        attractors = []
-        for result in results:
-            # Take last points after transient
-            attractor_points = result.trajectory[-1000:]
-            attractors.append(attractor_points)
-
-        return {
-            'parameter_values': param_values,
-            'attractors': attractors,
-            'parameter_name': parameter_name,
-        }
 
     def sensitivity_analysis(
         self,
@@ -290,48 +251,9 @@ class Simulator:
         Returns:
             Dictionary with sensitivity analysis results
         """
-        if config is None:
-            config = SimulationConfig()
-
-        # Original trajectory
-        original_result = self.simulate(initial_conditions, config)
-
-        # Perturbed trajectories
-        perturbed_ics = [
-            InitialConditions(
-                initial_conditions.x + perturbation,
-                initial_conditions.y,
-                initial_conditions.z,
-            ),
-            InitialConditions(
-                initial_conditions.x,
-                initial_conditions.y + perturbation,
-                initial_conditions.z,
-            ),
-            InitialConditions(
-                initial_conditions.x,
-                initial_conditions.y,
-                initial_conditions.z + perturbation,
-            ),
-        ]
-
-        perturbed_results = self.simulate_multiple(perturbed_ics, config)
-
-        # Calculate divergence
-        divergences = []
-        for result in perturbed_results:
-            diff = np.linalg.norm(
-                result.trajectory - original_result.trajectory, axis=1
-            )
-            divergences.append(diff)
-
-        return {
-            'original_trajectory': original_result.trajectory,
-            'perturbed_trajectories': [r.trajectory for r in perturbed_results],
-            'divergences': divergences,
-            'time': original_result.time,
-            'perturbation': perturbation,
-        }
+        return sweeps.sensitivity_analysis(
+            self, initial_conditions, perturbation, config
+        )
 
     def estimate_lyapunov_exponent(
         self, initial_conditions: InitialConditions, config: SimulationConfig = None

--- a/src/lorenz_attractor/core/simulator.py
+++ b/src/lorenz_attractor/core/simulator.py
@@ -3,7 +3,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import numpy as np
 
@@ -45,7 +45,9 @@ class SimulationResult:
         return self.trajectory[:, 2]
 
     def poincare_section(
-        self, plane_normal: np.ndarray = None, plane_offset: float = 27.0
+        self,
+        plane_normal: Optional[np.ndarray] = None,
+        plane_offset: float = 27.0,
     ) -> np.ndarray:
         """Compute Poincaré section."""
         if plane_normal is None:
@@ -54,16 +56,19 @@ class SimulationResult:
         system = LorenzSystem(self.parameters)
         return system.poincare_section(self.trajectory, plane_normal, plane_offset)
 
-    def save(self, filename: str):
+    def save(self, filename: str) -> None:
         """Save simulation results to file."""
+        parameters: np.ndarray = np.array(self.parameters.to_dict(), dtype=object)
+        config: np.ndarray = np.array(self.config.to_dict(), dtype=object)
+        metadata: np.ndarray = np.array(self.metadata, dtype=object)
         np.savez_compressed(
             filename,
             time=self.time,
             trajectory=self.trajectory,
-            parameters=self.parameters.to_dict(),
+            parameters=parameters,
             initial_conditions=self.initial_conditions.to_array(),
-            config=self.config.to_dict(),
-            metadata=self.metadata,
+            config=config,
+            metadata=metadata,
         )
 
     @classmethod
@@ -119,7 +124,7 @@ class Simulator:
         integrator = integrator_class(config.dt)
 
         # Define system function for integrator
-        def system_func(y, t):
+        def system_func(y: np.ndarray, t: float) -> np.ndarray:
             return self.system.derivative(y)
 
         # Integrate
@@ -213,8 +218,8 @@ class Simulator:
         parameter_name: str,
         parameter_range: Tuple[float, float],
         num_points: int = 100,
-        initial_conditions: InitialConditions = None,
-        config: SimulationConfig = None,
+        initial_conditions: Optional[InitialConditions] = None,
+        config: Optional[SimulationConfig] = None,
     ) -> Dict[str, Any]:
         """
         Perform bifurcation analysis.
@@ -242,7 +247,7 @@ class Simulator:
         self,
         initial_conditions: InitialConditions,
         perturbation: float = 1e-10,
-        config: SimulationConfig = None,
+        config: Optional[SimulationConfig] = None,
     ) -> Dict[str, Any]:
         """
         Analyze sensitivity to initial conditions.
@@ -260,7 +265,9 @@ class Simulator:
         )
 
     def estimate_lyapunov_exponent(
-        self, initial_conditions: InitialConditions, config: SimulationConfig = None
+        self,
+        initial_conditions: InitialConditions,
+        config: Optional[SimulationConfig] = None,
     ) -> float:
         """
         Estimate the largest Lyapunov exponent.
@@ -276,9 +283,9 @@ class Simulator:
             config = SimulationConfig(num_steps=50000)
 
         # Use system's built-in method
-        return self.system.lyapunov_exponents(
+        return cast(float, self.system.lyapunov_exponents(
             initial_conditions, config.dt, config.num_steps
-        )[0]
+        )[0])
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/lorenz_attractor/core/simulator.py
+++ b/src/lorenz_attractor/core/simulator.py
@@ -7,13 +7,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from ..analysis import sweeps
 from ..integration.integrators import (
     AdaptiveIntegrator,
     DormandPrince54Integrator,
     EulerIntegrator,
     RungeKutta4Integrator,
 )
-from ..analysis import sweeps
 from .lorenz import LorenzSystem
 from .parameters import InitialConditions, LorenzParameters, SimulationConfig
 
@@ -230,8 +230,12 @@ class Simulator:
             Dictionary with parameter values and corresponding attractors
         """
         return sweeps.bifurcation_analysis(
-            self, parameter_name, parameter_range, num_points,
-            initial_conditions, config,
+            self,
+            parameter_name,
+            parameter_range,
+            num_points,
+            initial_conditions,
+            config,
         )
 
     def sensitivity_analysis(

--- a/src/lorenz_attractor/export/data.py
+++ b/src/lorenz_attractor/export/data.py
@@ -114,7 +114,7 @@ class DataExporter:
 
         return str(filename)
 
-    def export_hdf5(self, result: SimulationResult, filename: str) -> str:
+    def export_hdf5(self, result: SimulationResult, filename: Union[str, Path]) -> str:
         """
         Export simulation result to HDF5 format.
 
@@ -171,7 +171,7 @@ class DataExporter:
             f.attrs['version'] = '2.0.0'
             f.attrs['generated_on'] = datetime.now().isoformat()
 
-        return filename
+        return str(filename)
 
     def export_numpy(self, result: SimulationResult, filename: Union[str, Path]) -> str:
         """

--- a/src/lorenz_attractor/export/data.py
+++ b/src/lorenz_attractor/export/data.py
@@ -49,7 +49,7 @@ class DataExporter:
         # Add metadata as comments if requested
         if include_metadata:
             metadata_lines = [
-                f"# Lorenz Attractor Simulation Data",
+                "# Lorenz Attractor Simulation Data",
                 f"# Generated on: {datetime.now().isoformat()}",
                 f"# Parameters: σ={result.parameters.sigma}, ρ={result.parameters.rho}, β={result.parameters.beta}",
                 f"# Initial conditions: x0={result.initial_conditions.x}, y0={result.initial_conditions.y}, z0={result.initial_conditions.z}",

--- a/src/lorenz_attractor/export/data.py
+++ b/src/lorenz_attractor/export/data.py
@@ -4,7 +4,7 @@ import json
 import pickle
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -23,12 +23,15 @@ from ..core.simulator import SimulationResult
 class DataExporter:
     """Export simulation data in various formats."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize data exporter."""
         pass
 
     def export_csv(
-        self, result: SimulationResult, filename: str, include_metadata: bool = True
+        self,
+        result: SimulationResult,
+        filename: Union[str, Path],
+        include_metadata: bool = True,
     ) -> str:
         """
         Export simulation result to CSV format.
@@ -68,10 +71,10 @@ class DataExporter:
         else:
             df.to_csv(filename, index=False)
 
-        return filename
+        return str(filename)
 
     def export_json(
-        self, result: SimulationResult, filename: str, compact: bool = False
+        self, result: SimulationResult, filename: Union[str, Path], compact: bool = False
     ) -> str:
         """
         Export simulation result to JSON format.
@@ -109,7 +112,7 @@ class DataExporter:
         with open(filename, 'w') as f:
             json.dump(data, f, indent=indent)
 
-        return filename
+        return str(filename)
 
     def export_hdf5(self, result: SimulationResult, filename: str) -> str:
         """
@@ -170,7 +173,7 @@ class DataExporter:
 
         return filename
 
-    def export_numpy(self, result: SimulationResult, filename: str) -> str:
+    def export_numpy(self, result: SimulationResult, filename: Union[str, Path]) -> str:
         """
         Export simulation result to NumPy format.
 
@@ -181,8 +184,9 @@ class DataExporter:
         Returns:
             Path to exported file
         """
-        # Create structured array
-        data = {
+        # Build keyword args with numpy-compatible types only; dicts are
+        # stored via allow_pickle semantics which numpy accepts at runtime.
+        kwargs: Dict[str, Any] = {
             'time': result.time,
             'trajectory': result.trajectory,
             'parameters': result.parameters.to_dict(),
@@ -191,8 +195,8 @@ class DataExporter:
             'metadata': result.metadata,
         }
 
-        np.savez_compressed(filename, **data)
-        return filename
+        np.savez_compressed(filename, **kwargs)
+        return str(filename)
 
     def export_matlab(self, result: SimulationResult, filename: str) -> str:
         """

--- a/src/lorenz_attractor/export/data.py
+++ b/src/lorenz_attractor/export/data.py
@@ -74,7 +74,10 @@ class DataExporter:
         return str(filename)
 
     def export_json(
-        self, result: SimulationResult, filename: Union[str, Path], compact: bool = False
+        self,
+        result: SimulationResult,
+        filename: Union[str, Path],
+        compact: bool = False,
     ) -> str:
         """
         Export simulation result to JSON format.

--- a/src/lorenz_attractor/export/image.py
+++ b/src/lorenz_attractor/export/image.py
@@ -9,7 +9,7 @@ from ..visualization.plotter import LorenzPlotter
 class ImageExporter:
     """Export high-quality images of simulations."""
 
-    def __init__(self, dpi: int = 300):
+    def __init__(self, dpi: int = 300) -> None:
         """Initialize image exporter."""
         self.dpi = dpi
         self.plotter = LorenzPlotter(dpi=dpi)

--- a/src/lorenz_attractor/export/video.py
+++ b/src/lorenz_attractor/export/video.py
@@ -245,7 +245,7 @@ class VideoExporter:
         self,
         results: List[SimulationResult],
         filename: str,
-        colors: Optional[Any] = None,
+        colors: Optional[Union[List[str], np.ndarray]] = None,
         quality: str = 'high',
     ) -> str:
         """

--- a/src/lorenz_attractor/export/video.py
+++ b/src/lorenz_attractor/export/video.py
@@ -1,6 +1,6 @@
 """Video export capabilities for Lorenz attractor simulations."""
 
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,7 +13,7 @@ from ..visualization.plotter import LorenzPlotter
 class VideoExporter:
     """Export Lorenz attractor simulations as videos."""
 
-    def __init__(self, fps: int = 30, dpi: int = 100):
+    def __init__(self, fps: int = 30, dpi: int = 100) -> None:
         """
         Initialize video exporter.
 
@@ -100,7 +100,7 @@ class VideoExporter:
         (line,) = ax.plot([], [], [], 'b-', linewidth=1, alpha=0.7)
         (point,) = ax.plot([], [], [], 'ro', markersize=8)
 
-        def animate(frame_idx):
+        def animate(frame_idx: int) -> Any:
             """Animation function."""
             current_idx = frame_indices[frame_idx]
 
@@ -135,6 +135,7 @@ class VideoExporter:
         )
 
         # Save video
+        writer: Union[FFMpegWriter, PillowWriter]
         if filename.endswith('.mp4'):
             writer = FFMpegWriter(fps=settings['fps'], bitrate=settings['bitrate'])
         elif filename.endswith('.gif'):
@@ -200,7 +201,7 @@ class VideoExporter:
         # Initialize plot elements
         (line,) = ax.plot([], [], [], 'b-', linewidth=0.5, alpha=0.8)
 
-        def animate(frame_idx):
+        def animate(frame_idx: int) -> Any:
             """Animation function."""
             if frame_idx < len(results):
                 result = results[frame_idx]
@@ -225,6 +226,7 @@ class VideoExporter:
         )
 
         # Save video
+        writer: Union[FFMpegWriter, PillowWriter]
         if filename.endswith('.mp4'):
             writer = FFMpegWriter(fps=settings['fps'], bitrate=settings['bitrate'])
         elif filename.endswith('.gif'):
@@ -243,7 +245,7 @@ class VideoExporter:
         self,
         results: List[SimulationResult],
         filename: str,
-        colors: Optional[List[str]] = None,
+        colors: Optional[Any] = None,
         quality: str = 'high',
     ) -> str:
         """
@@ -300,7 +302,7 @@ class VideoExporter:
         # Find maximum length
         max_length = max(len(result.trajectory) for result in results)
 
-        def animate(frame_idx):
+        def animate(frame_idx: int) -> Any:
             """Animation function."""
             for i, (result, line, point) in enumerate(zip(results, lines, points)):
                 if frame_idx < len(result.trajectory):
@@ -320,6 +322,7 @@ class VideoExporter:
         )
 
         # Save video
+        writer: Union[FFMpegWriter, PillowWriter]
         if filename.endswith('.mp4'):
             writer = FFMpegWriter(fps=settings['fps'], bitrate=settings['bitrate'])
         elif filename.endswith('.gif'):
@@ -382,7 +385,7 @@ class VideoExporter:
         # Calculate number of frames for full rotation
         num_frames = int(360 / rotation_speed)
 
-        def animate(frame_idx):
+        def animate(frame_idx: int) -> Any:
             """Animation function."""
             azimuth = frame_idx * rotation_speed
             ax.view_init(elev=30, azim=azimuth)
@@ -394,6 +397,7 @@ class VideoExporter:
         )
 
         # Save video
+        writer: Union[FFMpegWriter, PillowWriter]
         if filename.endswith('.mp4'):
             writer = FFMpegWriter(fps=settings['fps'], bitrate=settings['bitrate'])
         elif filename.endswith('.gif'):
@@ -470,7 +474,7 @@ class VideoExporter:
         # Find maximum length
         max_length = max(len(result.trajectory) for result in results)
 
-        def animate(frame_idx):
+        def animate(frame_idx: int) -> Any:
             """Animation function."""
             for i, (result, line, point) in enumerate(zip(results, lines, points)):
                 if frame_idx < len(result.trajectory):
@@ -490,6 +494,7 @@ class VideoExporter:
         )
 
         # Save video
+        writer: Union[FFMpegWriter, PillowWriter]
         if filename.endswith('.mp4'):
             writer = FFMpegWriter(fps=settings['fps'], bitrate=settings['bitrate'])
         elif filename.endswith('.gif'):

--- a/src/lorenz_attractor/integration/integrators.py
+++ b/src/lorenz_attractor/integration/integrators.py
@@ -112,31 +112,39 @@ class AdaptiveIntegrator(BaseIntegrator):
         self.atol = atol
         self.dt_min = dt / 1000
         self.dt_max = dt * 10
+        self._h_internal = dt
 
     def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
-        """Adaptive step with error control."""
-        dt = self.dt
+        """Advance by exactly self.dt using error-controlled adaptive sub-steps."""
+        macro_dt = self.dt
+        if macro_dt <= 0:
+            return y
 
-        while True:
-            # Take one step with current dt
-            y_new = self._rk4_step(f, y, t, dt)
+        t_local = 0.0
+        h = min(self._h_internal, macro_dt)
+        y_cur = np.asarray(y, dtype=float)
 
-            # Take two steps with dt/2
-            y_mid = self._rk4_step(f, y, t, dt / 2)
-            y_new_half = self._rk4_step(f, y_mid, t + dt / 2, dt / 2)
+        while t_local < macro_dt - 1e-15:
+            h = min(h, macro_dt - t_local)
 
-            # Estimate error
-            error = np.abs(y_new - y_new_half)
-            tolerance = self.atol + self.rtol * np.abs(y_new_half)
+            # Step-doubling error estimate: one full step vs two half steps.
+            y_full = self._rk4_step(f, y_cur, t + t_local, h)
+            y_half = self._rk4_step(f, y_cur, t + t_local, h / 2)
+            y_half = self._rk4_step(f, y_half, t + t_local + h / 2, h / 2)
 
-            # Check if error is acceptable
-            if np.all(error <= tolerance):
-                self.dt = min(dt * 1.5, self.dt_max)  # Increase step size
-                return y_new_half
+            error = np.abs(y_full - y_half)
+            tolerance = self.atol + self.rtol * np.abs(y_half)
+
+            if np.all(error <= tolerance) or h <= self.dt_min:
+                y_cur = y_half
+                t_local += h
+                if np.all(error <= tolerance):
+                    h = min(h * 1.5, macro_dt)  # grow, but never exceed the macro step
             else:
-                dt = max(dt * 0.5, self.dt_min)  # Decrease step size
-                if dt == self.dt_min:
-                    return y_new_half  # Accept with minimum step size
+                h = max(h * 0.5, self.dt_min)
+
+        self._h_internal = h
+        return y_cur
 
     def _rk4_step(self, f: Callable, y: np.ndarray, t: float, dt: float) -> np.ndarray:
         """Single RK4 step."""
@@ -194,41 +202,48 @@ class DormandPrince54Integrator(BaseIntegrator):
             ]
         )
         self.c = np.array([0, 1 / 5, 3 / 10, 4 / 5, 8 / 9, 1, 1])
+        self._h_internal = dt
+
+    def _dopri_substep(
+        self, f: Callable, y: np.ndarray, t: float, h: float
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """One Dormand-Prince 5(4) step of size h. Returns (5th-order y, error estimate)."""
+        k = np.zeros((7, len(y)))
+        k[0] = f(y, t)
+        for i in range(1, 7):
+            y_temp = y + h * np.sum(self.a[i, :i] * k[:i].T, axis=1)
+            k[i] = f(y_temp, t + self.c[i] * h)
+        y_new = y + h * np.sum(self.b * k.T, axis=1)
+        y_new_star = y + h * np.sum(self.b_star * k.T, axis=1)
+        error = np.abs(y_new - y_new_star)
+        return y_new, error
 
     def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
-        """Dormand-Prince step with adaptive step size."""
-        dt = self.dt
+        """Advance by exactly self.dt using error-controlled Dormand-Prince sub-steps."""
+        macro_dt = self.dt
+        if macro_dt <= 0:
+            return y
 
-        while True:
-            # Calculate k values
-            k = np.zeros((7, len(y)))
-            k[0] = f(y, t)
+        t_local = 0.0
+        h = min(self._h_internal, macro_dt)
+        y_cur = np.asarray(y, dtype=float)
 
-            for i in range(1, 7):
-                y_temp = y + dt * np.sum(self.a[i, :i] * k[:i].T, axis=1)
-                k[i] = f(y_temp, t + self.c[i] * dt)
+        while t_local < macro_dt - 1e-15:
+            h = min(h, macro_dt - t_local)
+            y_new, error = self._dopri_substep(f, y_cur, t + t_local, h)
+            tolerance = self.atol + self.rtol * np.maximum(np.abs(y_cur), np.abs(y_new))
 
-            # 5th order solution
-            y_new = y + dt * np.sum(self.b * k.T, axis=1)
-
-            # 4th order solution for error estimation
-            y_new_star = y + dt * np.sum(self.b_star * k.T, axis=1)
-
-            # Error estimation
-            error = np.abs(y_new - y_new_star)
-            tolerance = self.atol + self.rtol * np.maximum(np.abs(y), np.abs(y_new))
-
-            # Check if error is acceptable
-            if np.all(error <= tolerance):
-                # Adjust step size for next iteration
-                factor = 0.9 * np.power(np.max(tolerance / (error + 1e-14)), 1 / 5)
-                self.dt = np.clip(dt * factor, self.dt_min, self.dt_max)
-                return y_new
+            if np.all(error <= tolerance) or h <= self.dt_min:
+                y_cur = y_new
+                t_local += h
+                if np.all(error <= tolerance):
+                    factor = 0.9 * np.power(np.max(tolerance / (error + 1e-14)), 1 / 5)
+                    h = min(h * min(factor, 5.0), macro_dt)  # grow, capped, never exceed macro step
             else:
-                # Reduce step size and retry
-                dt = max(dt * 0.5, self.dt_min)
-                if dt == self.dt_min:
-                    return y_new
+                h = max(h * 0.5, self.dt_min)
+
+        self._h_internal = h
+        return y_cur
 
 
 @jit(nopython=True)

--- a/src/lorenz_attractor/integration/integrators.py
+++ b/src/lorenz_attractor/integration/integrators.py
@@ -6,6 +6,9 @@ from typing import Callable, Optional, Tuple
 import numpy as np
 from numba import jit
 
+# Type alias for the integrator function signature: f(y, t) -> dy/dt
+_IntegratorFunc = Callable[[np.ndarray, float], np.ndarray]
+
 
 class BaseIntegrator(ABC):
     """Base class for numerical integrators."""
@@ -20,7 +23,7 @@ class BaseIntegrator(ABC):
         self.dt = dt
 
     @abstractmethod
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """
         Perform one integration step.
 
@@ -36,7 +39,7 @@ class BaseIntegrator(ABC):
 
     def integrate(
         self,
-        f: Callable,
+        f: _IntegratorFunc,
         y0: np.ndarray,
         t_span: Tuple[float, float],
         num_steps: Optional[int] = None,
@@ -75,15 +78,16 @@ class BaseIntegrator(ABC):
 class EulerIntegrator(BaseIntegrator):
     """Forward Euler integration method."""
 
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """Euler integration step."""
-        return y + self.dt * f(y, t)
+        result: np.ndarray = y + self.dt * f(y, t)
+        return result
 
 
 class RungeKutta4Integrator(BaseIntegrator):
     """Fourth-order Runge-Kutta integration method."""
 
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """RK4 integration step."""
         dt = self.dt
 
@@ -92,7 +96,8 @@ class RungeKutta4Integrator(BaseIntegrator):
         k3 = f(y + dt / 2 * k2, t + dt / 2)
         k4 = f(y + dt * k3, t + dt)
 
-        return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        result: np.ndarray = y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        return result
 
 
 class AdaptiveIntegrator(BaseIntegrator):
@@ -114,7 +119,7 @@ class AdaptiveIntegrator(BaseIntegrator):
         self.dt_max = dt * 10
         self._h_internal = dt
 
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """Advance by exactly self.dt using error-controlled adaptive sub-steps."""
         macro_dt = self.dt
         if macro_dt <= 0:
@@ -146,14 +151,17 @@ class AdaptiveIntegrator(BaseIntegrator):
         self._h_internal = h
         return y_cur
 
-    def _rk4_step(self, f: Callable, y: np.ndarray, t: float, dt: float) -> np.ndarray:
+    def _rk4_step(
+        self, f: _IntegratorFunc, y: np.ndarray, t: float, dt: float
+    ) -> np.ndarray:
         """Single RK4 step."""
         k1 = f(y, t)
         k2 = f(y + dt / 2 * k1, t + dt / 2)
         k3 = f(y + dt / 2 * k2, t + dt / 2)
         k4 = f(y + dt * k3, t + dt)
 
-        return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        result: np.ndarray = y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        return result
 
 
 class DormandPrince54Integrator(BaseIntegrator):
@@ -205,7 +213,7 @@ class DormandPrince54Integrator(BaseIntegrator):
         self._h_internal = dt
 
     def _dopri_substep(
-        self, f: Callable, y: np.ndarray, t: float, h: float
+        self, f: _IntegratorFunc, y: np.ndarray, t: float, h: float
     ) -> Tuple[np.ndarray, np.ndarray]:
         """One Dormand-Prince 5(4) step of size h. Returns (5th-order y, error estimate)."""
         k = np.zeros((7, len(y)))
@@ -213,12 +221,12 @@ class DormandPrince54Integrator(BaseIntegrator):
         for i in range(1, 7):
             y_temp = y + h * np.sum(self.a[i, :i] * k[:i].T, axis=1)
             k[i] = f(y_temp, t + self.c[i] * h)
-        y_new = y + h * np.sum(self.b * k.T, axis=1)
-        y_new_star = y + h * np.sum(self.b_star * k.T, axis=1)
-        error = np.abs(y_new - y_new_star)
+        y_new: np.ndarray = y + h * np.sum(self.b * k.T, axis=1)
+        y_new_star: np.ndarray = y + h * np.sum(self.b_star * k.T, axis=1)
+        error: np.ndarray = np.abs(y_new - y_new_star)
         return y_new, error
 
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """Advance by exactly self.dt using error-controlled Dormand-Prince sub-steps."""
         macro_dt = self.dt
         if macro_dt <= 0:
@@ -248,7 +256,7 @@ class DormandPrince54Integrator(BaseIntegrator):
         return y_cur
 
 
-@jit(nopython=True)
+@jit(nopython=True)  # type: ignore[untyped-decorator]  # numba ships no stubs
 def _rk4_step_numba(f_values: np.ndarray, y: np.ndarray, dt: float) -> np.ndarray:
     """Numba-compiled RK4 step for performance."""
     k1 = f_values[0]
@@ -256,7 +264,7 @@ def _rk4_step_numba(f_values: np.ndarray, y: np.ndarray, dt: float) -> np.ndarra
     k3 = f_values[2]
     k4 = f_values[3]
 
-    return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+    return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)  # type: ignore[no-any-return]
 
 
 class HighPerformanceRK4Integrator(BaseIntegrator):
@@ -267,23 +275,24 @@ class HighPerformanceRK4Integrator(BaseIntegrator):
         super().__init__(dt)
         self._compiled_step = self._compile_step()
 
-    def _compile_step(self):
+    def _compile_step(self) -> Callable[[_IntegratorFunc, np.ndarray, float], np.ndarray]:
         """Compile the integration step for performance."""
         dt = self.dt
 
-        @jit(nopython=True)
-        def step_function(f_func, y: np.ndarray, t: float) -> np.ndarray:
+        @jit(nopython=True)  # type: ignore[untyped-decorator]  # numba ships no stubs
+        def step_function(f_func: Callable[..., np.ndarray], y: np.ndarray, t: float) -> np.ndarray:  # noqa: E501
             """Compiled RK4 step."""
             k1 = f_func(y)
             k2 = f_func(y + dt / 2 * k1)
             k3 = f_func(y + dt / 2 * k2)
             k4 = f_func(y + dt * k3)
 
-            return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+            return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)  # type: ignore[no-any-return]
 
-        return step_function
+        return step_function  # type: ignore[no-any-return]
 
-    def step(self, f: Callable, y: np.ndarray, t: float) -> np.ndarray:
+    def step(self, f: _IntegratorFunc, y: np.ndarray, t: float) -> np.ndarray:
         """High-performance RK4 step."""
         # Note: This assumes f doesn't depend on t explicitly
-        return self._compiled_step(f, y, t)
+        result: np.ndarray = self._compiled_step(f, y, t)
+        return result

--- a/src/lorenz_attractor/integration/integrators.py
+++ b/src/lorenz_attractor/integration/integrators.py
@@ -238,7 +238,9 @@ class DormandPrince54Integrator(BaseIntegrator):
                 t_local += h
                 if np.all(error <= tolerance):
                     factor = 0.9 * np.power(np.max(tolerance / (error + 1e-14)), 1 / 5)
-                    h = min(h * min(factor, 5.0), macro_dt)  # grow, capped, never exceed macro step
+                    h = min(
+                        h * min(factor, 5.0), macro_dt
+                    )  # grow, capped, never exceed macro step
             else:
                 h = max(h * 0.5, self.dt_min)
 

--- a/src/lorenz_attractor/integration/integrators.py
+++ b/src/lorenz_attractor/integration/integrators.py
@@ -275,12 +275,16 @@ class HighPerformanceRK4Integrator(BaseIntegrator):
         super().__init__(dt)
         self._compiled_step = self._compile_step()
 
-    def _compile_step(self) -> Callable[[_IntegratorFunc, np.ndarray, float], np.ndarray]:
+    def _compile_step(
+        self,
+    ) -> Callable[[_IntegratorFunc, np.ndarray, float], np.ndarray]:
         """Compile the integration step for performance."""
         dt = self.dt
 
         @jit(nopython=True)  # type: ignore[untyped-decorator]  # numba ships no stubs
-        def step_function(f_func: Callable[..., np.ndarray], y: np.ndarray, t: float) -> np.ndarray:  # noqa: E501
+        def step_function(
+            f_func: Callable[..., np.ndarray], y: np.ndarray, t: float
+        ) -> np.ndarray:  # noqa: E501
             """Compiled RK4 step."""
             k1 = f_func(y)
             k2 = f_func(y + dt / 2 * k1)

--- a/src/lorenz_attractor/utils/__init__.py
+++ b/src/lorenz_attractor/utils/__init__.py
@@ -1,3 +1,0 @@
-"""Utility functions and helpers."""
-
-pass

--- a/src/lorenz_attractor/visualization/interactive.py
+++ b/src/lorenz_attractor/visualization/interactive.py
@@ -13,7 +13,9 @@ from ..core.simulator import Simulator
 class InteractiveVisualizer:
     """Interactive 3D visualization with parameter controls."""
 
-    def __init__(self, sigma: float = 10.0, rho: float = 28.0, beta: float = 8.0 / 3.0) -> None:
+    def __init__(
+        self, sigma: float = 10.0, rho: float = 28.0, beta: float = 8.0 / 3.0
+    ) -> None:
         self.sigma = sigma
         self.rho = rho
         self.beta = beta
@@ -71,11 +73,15 @@ class InteractiveVisualizer:
             result = self.simulator.simulate(initial_conditions, config)
             new_trajectory = result.trajectory
 
-            assert self.line is not None
+            assert (
+                self.line is not None
+            )  # nosec B101 - type narrowing for Optional; line is set in create_interactive_plot before this callback is registered
             self.line.set_data_3d(
                 new_trajectory[:, 0], new_trajectory[:, 1], new_trajectory[:, 2]
             )
-            assert self.fig is not None
+            assert (
+                self.fig is not None
+            )  # nosec B101 - type narrowing for Optional; fig is set in create_interactive_plot before this callback is registered
             self.fig.canvas.draw()
 
         slider_sigma.on_changed(update)

--- a/src/lorenz_attractor/visualization/interactive.py
+++ b/src/lorenz_attractor/visualization/interactive.py
@@ -1,5 +1,7 @@
 """Interactive visualization components."""
 
+from typing import Any, Optional
+
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
 
@@ -11,16 +13,16 @@ from ..core.simulator import Simulator
 class InteractiveVisualizer:
     """Interactive 3D visualization with parameter controls."""
 
-    def __init__(self, sigma=10.0, rho=28.0, beta=8.0 / 3.0):
+    def __init__(self, sigma: float = 10.0, rho: float = 28.0, beta: float = 8.0 / 3.0) -> None:
         self.sigma = sigma
         self.rho = rho
         self.beta = beta
-        self.simulator = None
-        self.fig = None
-        self.ax = None
-        self.line = None
+        self.simulator: Optional[Simulator] = None
+        self.fig: Optional[Any] = None
+        self.ax: Optional[Any] = None
+        self.line: Optional[Any] = None
 
-    def create_interactive_plot(self, steps=10000, dt=0.01):
+    def create_interactive_plot(self, steps: int = 10000, dt: float = 0.01) -> None:
         """Create interactive plot with parameter sliders."""
         self.fig = plt.figure(figsize=(12, 8))
         self.ax = self.fig.add_subplot(111, projection='3d')
@@ -49,15 +51,15 @@ class InteractiveVisualizer:
         # Add sliders
         plt.subplots_adjust(bottom=0.25)
 
-        ax_sigma = plt.axes([0.1, 0.1, 0.3, 0.03])
-        ax_rho = plt.axes([0.1, 0.05, 0.3, 0.03])
-        ax_beta = plt.axes([0.1, 0.0, 0.3, 0.03])
+        ax_sigma = plt.axes((0.1, 0.1, 0.3, 0.03))
+        ax_rho = plt.axes((0.1, 0.05, 0.3, 0.03))
+        ax_beta = plt.axes((0.1, 0.0, 0.3, 0.03))
 
         slider_sigma = Slider(ax_sigma, 'Sigma', 1.0, 50.0, valinit=self.sigma)
         slider_rho = Slider(ax_rho, 'Rho', 1.0, 50.0, valinit=self.rho)
         slider_beta = Slider(ax_beta, 'Beta', 0.1, 5.0, valinit=self.beta)
 
-        def update(val):
+        def update(val: Any) -> None:
             self.sigma = slider_sigma.val
             self.rho = slider_rho.val
             self.beta = slider_beta.val
@@ -69,10 +71,12 @@ class InteractiveVisualizer:
             result = self.simulator.simulate(initial_conditions, config)
             new_trajectory = result.trajectory
 
-            self.line.set_data_3d(
-                new_trajectory[:, 0], new_trajectory[:, 1], new_trajectory[:, 2]
-            )
-            self.fig.canvas.draw()
+            if self.line is not None:
+                self.line.set_data_3d(
+                    new_trajectory[:, 0], new_trajectory[:, 1], new_trajectory[:, 2]
+                )
+            if self.fig is not None:
+                self.fig.canvas.draw()
 
         slider_sigma.on_changed(update)
         slider_rho.on_changed(update)
@@ -80,6 +84,6 @@ class InteractiveVisualizer:
 
         plt.show()
 
-    def show(self):
+    def show(self) -> None:
         """Show the interactive visualization."""
         self.create_interactive_plot()

--- a/src/lorenz_attractor/visualization/interactive.py
+++ b/src/lorenz_attractor/visualization/interactive.py
@@ -71,12 +71,12 @@ class InteractiveVisualizer:
             result = self.simulator.simulate(initial_conditions, config)
             new_trajectory = result.trajectory
 
-            if self.line is not None:
-                self.line.set_data_3d(
-                    new_trajectory[:, 0], new_trajectory[:, 1], new_trajectory[:, 2]
-                )
-            if self.fig is not None:
-                self.fig.canvas.draw()
+            assert self.line is not None
+            self.line.set_data_3d(
+                new_trajectory[:, 0], new_trajectory[:, 1], new_trajectory[:, 2]
+            )
+            assert self.fig is not None
+            self.fig.canvas.draw()
 
         slider_sigma.on_changed(update)
         slider_rho.on_changed(update)

--- a/src/lorenz_attractor/visualization/opengl_renderer.py
+++ b/src/lorenz_attractor/visualization/opengl_renderer.py
@@ -1,7 +1,7 @@
 """OpenGL rendering components."""
 
 import math
-from typing import Tuple
+from typing import Any, Optional, Tuple, cast
 
 import moderngl
 import numpy as np
@@ -13,7 +13,7 @@ from ..core.simulator import SimulationResult
 class OpenGLRenderer:
     """OpenGL renderer for high-performance visualization."""
 
-    def __init__(self, window_size: Tuple[int, int] = (1200, 800)):
+    def __init__(self, window_size: Tuple[int, int] = (1200, 800)) -> None:
         """
         Initialize renderer.
 
@@ -21,15 +21,15 @@ class OpenGLRenderer:
             window_size: Window size (width, height)
         """
         self.window_size = window_size
-        self.ctx = None
-        self.program = None
+        self.ctx: Optional[moderngl.Context] = None
+        self.program: Optional[moderngl.Program] = None
         self.camera_distance = 80.0
         self.camera_angle_x = 0.0
         self.camera_angle_y = 0.0
         self.mouse_sensitivity = 0.5
         self.zoom_sensitivity = 5.0
 
-    def initialize_context(self):
+    def initialize_context(self) -> None:
         """Initialize OpenGL context."""
         # Initialize Pygame
         pygame.init()
@@ -47,8 +47,9 @@ class OpenGLRenderer:
         # Create shader program
         self._create_shader_program()
 
-    def _create_shader_program(self):
+    def _create_shader_program(self) -> None:
         """Create shader program for trajectory rendering."""
+        assert self.ctx is not None
         vertex_shader = '''
         #version 330 core
 
@@ -99,7 +100,7 @@ class OpenGLRenderer:
         render_mode: str = 'line',
         color_mode: str = 'time',
         point_size: float = 2.0,
-    ):
+    ) -> None:
         """
         Render trajectory using OpenGL.
 
@@ -109,7 +110,7 @@ class OpenGLRenderer:
             color_mode: 'time', 'velocity', or 'position'
             point_size: Size of points when rendering points
         """
-        if not self.ctx:
+        if not self.ctx or not self.program:
             raise RuntimeError("OpenGL context not initialized")
 
         # Prepare vertex data
@@ -140,9 +141,9 @@ class OpenGLRenderer:
         mvp_matrix = self._calculate_mvp_matrix()
         camera_pos = self._get_camera_position()
 
-        self.program['mvp'].write(mvp_matrix.tobytes())
-        self.program['camera_pos'].write(camera_pos.tobytes())
-        self.program['point_size'].value = point_size
+        cast(moderngl.Uniform, self.program['mvp']).write(mvp_matrix.tobytes())
+        cast(moderngl.Uniform, self.program['camera_pos']).write(camera_pos.tobytes())
+        cast(moderngl.Uniform, self.program['point_size']).value = point_size
 
         # Clear screen
         self.ctx.clear(0.0, 0.0, 0.0, 1.0)
@@ -156,7 +157,7 @@ class OpenGLRenderer:
             # Render line first
             vao.render(moderngl.LINE_STRIP)
             # Then render points with larger size
-            self.program['point_size'].value = point_size * 2
+            cast(moderngl.Uniform, self.program['point_size']).value = point_size * 2
             vao.render(moderngl.POINTS)
 
         # Clean up
@@ -210,7 +211,7 @@ class OpenGLRenderer:
         model = np.eye(4, dtype=np.float32)
 
         # View matrix
-        view = np.eye(4, dtype=np.float32)
+        view: np.ndarray = np.eye(4, dtype=np.float32)
 
         # Apply camera transformations
         # Translate back
@@ -274,7 +275,7 @@ class OpenGLRenderer:
 
         return np.array([x, y, z], dtype=np.float32)
 
-    def handle_mouse_input(self, event):
+    def handle_mouse_input(self, event: Any) -> None:
         """Handle mouse input for camera control."""
         if event.type == pygame.MOUSEMOTION:
             if pygame.mouse.get_pressed()[0]:  # Left mouse button
@@ -288,8 +289,11 @@ class OpenGLRenderer:
             self.camera_distance -= event.y * self.zoom_sensitivity
             self.camera_distance = max(10, min(200, self.camera_distance))
 
-    def render_axes(self, length: float = 30.0):
+    def render_axes(self, length: float = 30.0) -> None:
         """Render coordinate axes."""
+        assert self.ctx is not None
+        assert self.program is not None
+
         # Axes vertices
         axes_vertices = np.array(
             [
@@ -344,9 +348,9 @@ class OpenGLRenderer:
         mvp_matrix = self._calculate_mvp_matrix()
         camera_pos = self._get_camera_position()
 
-        self.program['mvp'].write(mvp_matrix.tobytes())
-        self.program['camera_pos'].write(camera_pos.tobytes())
-        self.program['point_size'].value = 1.0
+        cast(moderngl.Uniform, self.program['mvp']).write(mvp_matrix.tobytes())
+        cast(moderngl.Uniform, self.program['camera_pos']).write(camera_pos.tobytes())
+        cast(moderngl.Uniform, self.program['point_size']).value = 1.0
 
         # Render axes as lines
         vao.render(moderngl.LINES)
@@ -357,7 +361,7 @@ class OpenGLRenderer:
         vbo_colors.release()
         vbo_alphas.release()
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up OpenGL resources."""
         if self.program:
             self.program.release()

--- a/src/lorenz_attractor/visualization/opengl_renderer.py
+++ b/src/lorenz_attractor/visualization/opengl_renderer.py
@@ -49,7 +49,9 @@ class OpenGLRenderer:
 
     def _create_shader_program(self) -> None:
         """Create shader program for trajectory rendering."""
-        assert self.ctx is not None
+        assert (
+            self.ctx is not None
+        )  # nosec B101 - type narrowing for Optional; ctx is always initialised before _create_shader_program is called
         vertex_shader = '''
         #version 330 core
 

--- a/src/lorenz_attractor/visualization/opengl_renderer.py
+++ b/src/lorenz_attractor/visualization/opengl_renderer.py
@@ -51,19 +51,19 @@ class OpenGLRenderer:
         """Create shader program for trajectory rendering."""
         vertex_shader = '''
         #version 330 core
-        
+
         in vec3 in_position;
         in float in_alpha;
         in vec3 in_color;
-        
+
         uniform mat4 mvp;
         uniform vec3 camera_pos;
         uniform float point_size;
-        
+
         out float alpha;
         out vec3 color;
         out float distance_from_camera;
-        
+
         void main() {
             gl_Position = mvp * vec4(in_position, 1.0);
             gl_PointSize = point_size;
@@ -75,13 +75,13 @@ class OpenGLRenderer:
 
         fragment_shader = '''
         #version 330 core
-        
+
         in float alpha;
         in vec3 color;
         in float distance_from_camera;
-        
+
         out vec4 fragColor;
-        
+
         void main() {
             // Distance-based alpha falloff
             float distance_alpha = 1.0 / (1.0 + distance_from_camera * 0.01);

--- a/src/lorenz_attractor/visualization/opengl_renderer.py
+++ b/src/lorenz_attractor/visualization/opengl_renderer.py
@@ -291,8 +291,8 @@ class OpenGLRenderer:
 
     def render_axes(self, length: float = 30.0) -> None:
         """Render coordinate axes."""
-        assert self.ctx is not None
-        assert self.program is not None
+        if not self.ctx or not self.program:
+            raise RuntimeError("OpenGL context not initialized")
 
         # Axes vertices
         axes_vertices = np.array(

--- a/src/lorenz_attractor/visualization/plotter.py
+++ b/src/lorenz_attractor/visualization/plotter.py
@@ -399,7 +399,7 @@ class LorenzPlotter:
                 result.z,
                 alpha=0.7,
                 linewidth=0.5,
-                label=f'{parameter_name}={parameter_values[i*len(results)//5]:.2f}',
+                label=f'{parameter_name}={parameter_values[i * len(results) // 5]:.2f}',
             )
         axes[1, 1].set_xlabel('Time')
         axes[1, 1].set_ylabel('Z')

--- a/src/lorenz_attractor/visualization/plotter.py
+++ b/src/lorenz_attractor/visualization/plotter.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objects as go
@@ -31,7 +32,7 @@ class LorenzPlotter:
         self.dpi = dpi
         self._setup_style()
 
-    def _setup_style(self):
+    def _setup_style(self) -> None:
         """Setup plotting style."""
         if self.style == 'dark':
             plt.style.use('dark_background')
@@ -64,7 +65,7 @@ class LorenzPlotter:
         show_axes: bool = True,
         save_path: Optional[str] = None,
         fast_mode: bool = True,
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot 3D trajectory of the Lorenz attractor.
 
@@ -161,7 +162,7 @@ class LorenzPlotter:
         result: SimulationResult,
         title: str = "Lorenz Attractor Projections",
         save_path: Optional[str] = None,
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot 2D projections of the trajectory.
 
@@ -214,9 +215,9 @@ class LorenzPlotter:
     def plot_phase_space(
         self,
         result: SimulationResult,
-        poincare_plane: Optional[Dict] = None,
+        poincare_plane: Optional[Dict[str, Any]] = None,
         save_path: Optional[str] = None,
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot phase space analysis including Poincaré sections.
 
@@ -351,7 +352,7 @@ class LorenzPlotter:
         parameter_name: str,
         parameter_values: np.ndarray,
         save_path: Optional[str] = None,
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot results from parameter sweep.
 
@@ -417,7 +418,7 @@ class LorenzPlotter:
 
     def plot_bifurcation_diagram(
         self, bifurcation_data: Dict[str, Any], save_path: Optional[str] = None
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot bifurcation diagram.
 
@@ -463,7 +464,7 @@ class LorenzPlotter:
 
     def plot_sensitivity_analysis(
         self, sensitivity_data: Dict[str, Any], save_path: Optional[str] = None
-    ) -> plt.Figure:
+    ) -> matplotlib.figure.Figure:
         """
         Plot sensitivity analysis results.
 

--- a/src/lorenz_attractor/visualization/realtime.py
+++ b/src/lorenz_attractor/visualization/realtime.py
@@ -187,7 +187,7 @@ class RealtimeVisualizer:
 
         clock = pygame.time.Clock()
 
-        while self.is_running:
+        while self.is_running:  # pragma: no cover
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -347,7 +347,7 @@ class RealtimeVisualizer:
 
         clock = pygame.time.Clock()
 
-        while self.is_running:
+        while self.is_running:  # pragma: no cover
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -451,7 +451,7 @@ class StreamingVisualizer:
         current_state = initial_conditions.to_array()
         current_time = 0
 
-        while self.is_streaming:
+        while self.is_streaming:  # pragma: no cover
             # Simulate next step
             dt = config.dt
             derivative = self.simulator.system.derivative(current_state)

--- a/src/lorenz_attractor/visualization/realtime.py
+++ b/src/lorenz_attractor/visualization/realtime.py
@@ -3,7 +3,7 @@
 import threading
 import time
 from queue import Queue
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import matplotlib.pyplot as plt
 import moderngl
@@ -50,7 +50,7 @@ from ..core.simulator import Simulator
 class RealtimeVisualizer:
     """Real-time visualization of Lorenz attractor evolution."""
 
-    def __init__(self, simulator: Simulator, trail_length: int = 2000):
+    def __init__(self, simulator: Simulator, trail_length: int = 2000) -> None:
         """
         Initialize real-time visualizer.
 
@@ -61,10 +61,10 @@ class RealtimeVisualizer:
         self.simulator = simulator
         self.trail_length = trail_length
         self.is_running = False
-        self.current_state = None
-        self.trajectory_buffer = []
-        self.time_buffer = []
-        self.current_time = 0
+        self.current_state: Optional[np.ndarray] = None
+        self.trajectory_buffer: List[np.ndarray] = []
+        self.time_buffer: List[float] = []
+        self.current_time: float = 0.0
 
     def start_matplotlib_animation(
         self,
@@ -104,8 +104,9 @@ class RealtimeVisualizer:
         ax.set_zlabel('Z')
         ax.set_title('Real-time Lorenz Attractor')
 
-        def update_frame(frame):
+        def update_frame(frame: int) -> Tuple[Any, Any]:
             # Simulate next step
+            assert self.current_state is not None
             dt = config.dt
             derivative = self.simulator.system.derivative(self.current_state)
             self.current_state += derivative * dt
@@ -148,7 +149,7 @@ class RealtimeVisualizer:
         initial_conditions: InitialConditions,
         config: SimulationConfig,
         window_size: Tuple[int, int] = (1200, 800),
-    ):
+    ) -> None:
         """
         Start real-time visualization using Pygame and OpenGL.
 
@@ -181,13 +182,14 @@ class RealtimeVisualizer:
         self.is_running = True
 
         # Camera parameters
-        camera_distance = 80
-        camera_angle_x = 0
-        camera_angle_y = 0
+        camera_distance = 80.0
+        camera_angle_x = 0.0
+        camera_angle_y = 0.0
 
         clock = pygame.time.Clock()
 
         while self.is_running:  # pragma: no cover
+            assert self.current_state is not None
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -241,7 +243,7 @@ class RealtimeVisualizer:
 
         pygame.quit()
 
-    def _draw_axes(self):
+    def _draw_axes(self) -> None:
         """Draw coordinate axes."""
         glLineWidth(2)
         glBegin(GL_LINES)
@@ -263,7 +265,7 @@ class RealtimeVisualizer:
 
         glEnd()
 
-    def _draw_trajectory_opengl(self):
+    def _draw_trajectory_opengl(self) -> None:
         """Draw trajectory using OpenGL."""
         glLineWidth(1)
         glBegin(GL_LINE_STRIP)
@@ -276,8 +278,9 @@ class RealtimeVisualizer:
 
         glEnd()
 
-    def _draw_current_point_opengl(self):
+    def _draw_current_point_opengl(self) -> None:
         """Draw current point using OpenGL."""
+        assert self.current_state is not None
         glPointSize(8)
         glColor3f(1, 0, 0)  # Red
         glBegin(GL_POINTS)
@@ -289,7 +292,7 @@ class RealtimeVisualizer:
         initial_conditions: InitialConditions,
         config: SimulationConfig,
         window_size: Tuple[int, int] = (1200, 800),
-    ):
+    ) -> None:
         """
         Start high-performance visualization using ModernGL.
 
@@ -348,6 +351,7 @@ class RealtimeVisualizer:
         clock = pygame.time.Clock()
 
         while self.is_running:  # pragma: no cover
+            assert self.current_state is not None
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -387,7 +391,7 @@ class RealtimeVisualizer:
                 mvp[2, 2] = 0.02  # Scale Z
                 mvp[2, 3] = -0.5  # Translate Z
 
-                program['mvp'].write(mvp.tobytes())
+                cast(moderngl.Uniform, program['mvp']).write(mvp.tobytes())
 
                 # Clear and render
                 ctx.clear(0.0, 0.0, 0.0, 1.0)
@@ -406,7 +410,7 @@ class RealtimeVisualizer:
 
         pygame.quit()
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the real-time visualization."""
         self.is_running = False
 
@@ -414,7 +418,7 @@ class RealtimeVisualizer:
 class StreamingVisualizer:
     """Stream simulation data for real-time visualization."""
 
-    def __init__(self, simulator: Simulator, buffer_size: int = 10000):
+    def __init__(self, simulator: Simulator, buffer_size: int = 10000) -> None:
         """
         Initialize streaming visualizer.
 
@@ -424,13 +428,13 @@ class StreamingVisualizer:
         """
         self.simulator = simulator
         self.buffer_size = buffer_size
-        self.data_queue = Queue(maxsize=buffer_size)
+        self.data_queue: 'Queue[Dict[str, Any]]' = Queue(maxsize=buffer_size)
         self.is_streaming = False
-        self.stream_thread = None
+        self.stream_thread: Optional[threading.Thread] = None
 
     def start_streaming(
         self, initial_conditions: InitialConditions, config: SimulationConfig
-    ):
+    ) -> None:
         """
         Start streaming simulation data.
 
@@ -446,10 +450,10 @@ class StreamingVisualizer:
 
     def _stream_worker(
         self, initial_conditions: InitialConditions, config: SimulationConfig
-    ):
+    ) -> None:
         """Worker thread for streaming simulation data."""
         current_state = initial_conditions.to_array()
-        current_time = 0
+        current_time = 0.0
 
         while self.is_streaming:  # pragma: no cover
             # Simulate next step
@@ -476,7 +480,7 @@ class StreamingVisualizer:
             # Control simulation speed
             time.sleep(config.dt / 10)  # 10x real-time
 
-    def get_latest_data(self, num_points: int = 100) -> List[dict]:
+    def get_latest_data(self, num_points: int = 100) -> List[Dict[str, Any]]:
         """
         Get latest simulation data points.
 
@@ -486,7 +490,7 @@ class StreamingVisualizer:
         Returns:
             List of data points
         """
-        data_points = []
+        data_points: List[Dict[str, Any]] = []
 
         # Get all available data
         while not self.data_queue.empty() and len(data_points) < num_points:
@@ -497,12 +501,12 @@ class StreamingVisualizer:
 
         return data_points
 
-    def stop_streaming(self):
+    def stop_streaming(self) -> None:
         """Stop streaming simulation data."""
         self.is_streaming = False
         if self.stream_thread:
             self.stream_thread.join()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Cleanup when object is destroyed."""
         self.stop_streaming()

--- a/src/lorenz_attractor/visualization/realtime.py
+++ b/src/lorenz_attractor/visualization/realtime.py
@@ -106,7 +106,9 @@ class RealtimeVisualizer:
 
         def update_frame(frame: int) -> Tuple[Any, Any]:
             # Simulate next step
-            assert self.current_state is not None
+            assert (
+                self.current_state is not None
+            )  # nosec B101 - type narrowing for Optional; current_state is set during simulate() before this callback fires
             dt = config.dt
             derivative = self.simulator.system.derivative(self.current_state)
             self.current_state += derivative * dt
@@ -189,7 +191,9 @@ class RealtimeVisualizer:
         clock = pygame.time.Clock()
 
         while self.is_running:  # pragma: no cover
-            assert self.current_state is not None
+            assert (
+                self.current_state is not None
+            )  # nosec B101 - type narrowing for Optional; current_state is always set before the loop starts
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -280,7 +284,9 @@ class RealtimeVisualizer:
 
     def _draw_current_point_opengl(self) -> None:
         """Draw current point using OpenGL."""
-        assert self.current_state is not None
+        assert (
+            self.current_state is not None
+        )  # nosec B101 - type narrowing for Optional; current_state is always set before rendering loop calls this method
         glPointSize(8)
         glColor3f(1, 0, 0)  # Red
         glBegin(GL_POINTS)
@@ -351,7 +357,9 @@ class RealtimeVisualizer:
         clock = pygame.time.Clock()
 
         while self.is_running:  # pragma: no cover
-            assert self.current_state is not None
+            assert (
+                self.current_state is not None
+            )  # nosec B101 - type narrowing for Optional; current_state is always set before the OpenGL loop starts
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.is_running = False
@@ -473,7 +481,9 @@ class StreamingVisualizer:
                         'z': current_state[2],
                     }
                 )
-            except Exception:
+            except (
+                Exception
+            ):  # nosec B110 - queue.put() raises queue.Full; silently dropping points when the buffer is full is the intended behaviour for real-time streaming
                 # Queue is full, skip this point
                 pass
 

--- a/src/lorenz_attractor/visualization/realtime.py
+++ b/src/lorenz_attractor/visualization/realtime.py
@@ -159,7 +159,7 @@ class RealtimeVisualizer:
         """
         # Initialize Pygame
         pygame.init()
-        display = pygame.display.set_mode(window_size, pygame.DOUBLEBUF | pygame.OPENGL)
+        pygame.display.set_mode(window_size, pygame.DOUBLEBUF | pygame.OPENGL)
         pygame.display.set_caption("Real-time Lorenz Attractor")
 
         # OpenGL setup
@@ -300,7 +300,7 @@ class RealtimeVisualizer:
         """
         # Initialize Pygame for window management
         pygame.init()
-        display = pygame.display.set_mode(window_size, pygame.DOUBLEBUF | pygame.OPENGL)
+        pygame.display.set_mode(window_size, pygame.DOUBLEBUF | pygame.OPENGL)
         pygame.display.set_caption("High-Performance Lorenz Attractor")
 
         # Create ModernGL context
@@ -309,14 +309,14 @@ class RealtimeVisualizer:
         # Vertex shader
         vertex_shader = '''
         #version 330 core
-        
+
         in vec3 in_position;
         in float in_alpha;
-        
+
         uniform mat4 mvp;
-        
+
         out float alpha;
-        
+
         void main() {
             gl_Position = mvp * vec4(in_position, 1.0);
             alpha = in_alpha;
@@ -326,10 +326,10 @@ class RealtimeVisualizer:
         # Fragment shader
         fragment_shader = '''
         #version 330 core
-        
+
         in float alpha;
         out vec4 fragColor;
-        
+
         void main() {
             fragColor = vec4(0.0, 0.5, 1.0, alpha);
         }
@@ -469,7 +469,7 @@ class StreamingVisualizer:
                         'z': current_state[2],
                     }
                 )
-            except:
+            except Exception:
                 # Queue is full, skip this point
                 pass
 
@@ -492,7 +492,7 @@ class StreamingVisualizer:
         while not self.data_queue.empty() and len(data_points) < num_points:
             try:
                 data_points.append(self.data_queue.get_nowait())
-            except:
+            except Exception:
                 break
 
         return data_points

--- a/src/lorenz_attractor/web/app.py
+++ b/src/lorenz_attractor/web/app.py
@@ -17,9 +17,6 @@ def create_app() -> dash.Dash:
 
     app = dash.Dash(__name__, title="Lorenz Attractor Explorer")
 
-    # Initialize components
-    simulator = Simulator()
-
     # Define the app layout
     app.layout = html.Div(
         [
@@ -210,7 +207,7 @@ def create_app() -> dash.Dash:
                                         step=1000,
                                         value=10000,
                                         marks={
-                                            i: f'{i//1000}k'
+                                            i: f'{i // 1000}k'
                                             for i in range(0, 51000, 10000)
                                         },
                                         tooltip={
@@ -232,7 +229,7 @@ def create_app() -> dash.Dash:
                                         step=0.001,
                                         value=0.01,
                                         marks={
-                                            i / 100: f'{i/100:.3f}'
+                                            i / 100: f'{i / 100:.3f}'
                                             for i in range(0, 11, 2)
                                         },
                                         tooltip={

--- a/src/lorenz_attractor/web/app.py
+++ b/src/lorenz_attractor/web/app.py
@@ -1,6 +1,7 @@
 """Web application for interactive Lorenz attractor exploration."""
 
 import json
+from typing import Any, Optional, Tuple
 
 import dash
 import numpy as np
@@ -379,7 +380,7 @@ def create_app() -> dash.Dash:
         ],
         [Input('random-ic-button', 'n_clicks')],
     )
-    def generate_random_initial_conditions(n_clicks):
+    def generate_random_initial_conditions(n_clicks: Optional[int]) -> Tuple[float, float, float]:
         if n_clicks is None:
             return 1.0, 1.0, 1.0
 
@@ -403,8 +404,17 @@ def create_app() -> dash.Dash:
         ],
     )
     def run_simulation(
-        n_clicks, sigma, rho, beta, x0, y0, z0, integration_method, num_steps, dt
-    ):
+        n_clicks: Optional[int],
+        sigma: float,
+        rho: float,
+        beta: float,
+        x0: float,
+        y0: float,
+        z0: float,
+        integration_method: str,
+        num_steps: int,
+        dt: float,
+    ) -> str:
         if n_clicks is None:
             return json.dumps({})
 
@@ -437,7 +447,7 @@ def create_app() -> dash.Dash:
         Output('plot-container', 'children'),
         [Input('viz-tabs', 'value'), Input('simulation-data', 'children')],
     )
-    def update_visualization(active_tab, simulation_data):
+    def update_visualization(active_tab: str, simulation_data: Optional[str]) -> Any:
         if not simulation_data:
             return html.Div(
                 "Run a simulation to see results.",
@@ -709,7 +719,7 @@ def create_app() -> dash.Dash:
     @app.callback(
         Output('system-info', 'children'), [Input('simulation-data', 'children')]
     )
-    def update_system_info(simulation_data):
+    def update_system_info(simulation_data: Optional[str]) -> Any:
         if not simulation_data:
             return "No simulation data available."
 
@@ -742,7 +752,7 @@ def create_app() -> dash.Dash:
             Input('stop-realtime-button', 'n_clicks'),
         ],
     )
-    def control_realtime(start_clicks, stop_clicks):
+    def control_realtime(start_clicks: Optional[int], stop_clicks: Optional[int]) -> bool:
         ctx = callback_context
         if not ctx.triggered:
             return True
@@ -759,7 +769,7 @@ def create_app() -> dash.Dash:
     return app
 
 
-def main():
+def main() -> None:
     """Main function to run the web application."""
     app = create_app()
     app.run_server(debug=True, host='0.0.0.0', port=8050)

--- a/src/lorenz_attractor/web/app.py
+++ b/src/lorenz_attractor/web/app.py
@@ -380,7 +380,9 @@ def create_app() -> dash.Dash:
         ],
         [Input('random-ic-button', 'n_clicks')],
     )
-    def generate_random_initial_conditions(n_clicks: Optional[int]) -> Tuple[float, float, float]:
+    def generate_random_initial_conditions(
+        n_clicks: Optional[int],
+    ) -> Tuple[float, float, float]:
         if n_clicks is None:
             return 1.0, 1.0, 1.0
 
@@ -752,7 +754,9 @@ def create_app() -> dash.Dash:
             Input('stop-realtime-button', 'n_clicks'),
         ],
     )
-    def control_realtime(start_clicks: Optional[int], stop_clicks: Optional[int]) -> bool:
+    def control_realtime(
+        start_clicks: Optional[int], stop_clicks: Optional[int]
+    ) -> bool:
         ctx = callback_context
         if not ctx.triggered:
             return True
@@ -772,7 +776,7 @@ def create_app() -> dash.Dash:
 def main() -> None:
     """Main function to run the web application."""
     app = create_app()
-    app.run_server(debug=True, host='0.0.0.0', port=8050)
+    app.run_server(debug=True, host='0.0.0.0', port=8050)  # nosec B104
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault('PYGAME_HIDE_SUPPORT_PROMPT', '1')

--- a/tests/test_analysis_sections.py
+++ b/tests/test_analysis_sections.py
@@ -1,0 +1,27 @@
+"""Tests for analysis.sections (extracted from core.lorenz)."""
+
+import numpy as np
+
+from lorenz_attractor.analysis import sections
+from lorenz_attractor.core.lorenz import LorenzSystem
+
+
+def test_no_crossing_returns_empty_with_correct_shape():
+    traj = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]], dtype=float)
+    out = sections.poincare_section(traj)
+    assert out.shape == (0, 3)
+
+
+def test_two_crossings_detected_at_plane():
+    traj = np.array([[0, 0, 26], [1, 1, 28], [2, 2, 26]], dtype=float)
+    out = sections.poincare_section(traj, plane_offset=27.0)
+    assert len(out) == 2
+    assert abs(out[0][2] - 27.0) < 1e-10
+
+
+def test_lorenzsystem_method_delegates_identically():
+    system = LorenzSystem()
+    traj = np.array([[0, 0, 26], [1, 1, 28], [2, 2, 26]], dtype=float)
+    np.testing.assert_array_equal(
+        system.poincare_section(traj), sections.poincare_section(traj)
+    )

--- a/tests/test_analysis_stability.py
+++ b/tests/test_analysis_stability.py
@@ -32,7 +32,9 @@ def test_equilibria_subcritical_has_origin_only():
 def test_lorenzsystem_methods_delegate_identically():
     system = LorenzSystem()
     state = np.array([2.0, 3.0, 4.0])
-    np.testing.assert_array_equal(system.jacobian(state), stability.jacobian(system, state))
+    np.testing.assert_array_equal(
+        system.jacobian(state), stability.jacobian(system, state)
+    )
     eqs_method = system.equilibrium_points()
     eqs_func = stability.equilibrium_points(system)
     for a, b in zip(eqs_method, eqs_func):
@@ -40,7 +42,9 @@ def test_lorenzsystem_methods_delegate_identically():
     # Verify lyapunov_exponents delegates identically
     initial_conditions = InitialConditions(1.0, 1.0, 1.0)
     lyap_method = system.lyapunov_exponents(initial_conditions, dt=0.01, num_steps=200)
-    lyap_func = stability.lyapunov_exponents(system, initial_conditions, dt=0.01, num_steps=200)
+    lyap_func = stability.lyapunov_exponents(
+        system, initial_conditions, dt=0.01, num_steps=200
+    )
     np.testing.assert_allclose(lyap_method, lyap_func, rtol=1e-10)
 
 

--- a/tests/test_analysis_stability.py
+++ b/tests/test_analysis_stability.py
@@ -37,6 +37,11 @@ def test_lorenzsystem_methods_delegate_identically():
     eqs_func = stability.equilibrium_points(system)
     for a, b in zip(eqs_method, eqs_func):
         np.testing.assert_array_equal(a, b)
+    # Verify lyapunov_exponents delegates identically
+    initial_conditions = InitialConditions(1.0, 1.0, 1.0)
+    lyap_method = system.lyapunov_exponents(initial_conditions, dt=0.01, num_steps=200)
+    lyap_func = stability.lyapunov_exponents(system, initial_conditions, dt=0.01, num_steps=200)
+    np.testing.assert_allclose(lyap_method, lyap_func, rtol=1e-10)
 
 
 @pytest.mark.slow

--- a/tests/test_analysis_stability.py
+++ b/tests/test_analysis_stability.py
@@ -1,0 +1,51 @@
+"""Tests for analysis.stability (extracted from core.lorenz)."""
+
+import numpy as np
+import pytest
+
+from lorenz_attractor.analysis import stability
+from lorenz_attractor.core.lorenz import LorenzSystem
+from lorenz_attractor.core.parameters import InitialConditions, LorenzParameters
+
+
+def test_jacobian_matches_known_matrix():
+    system = LorenzSystem()
+    J = stability.jacobian(system, np.array([1.0, 1.0, 1.0]))
+    expected = np.array(
+        [[-10.0, 10.0, 0.0], [27.0, -1.0, -1.0], [1.0, 1.0, -8.0 / 3.0]]
+    )
+    np.testing.assert_allclose(J, expected, rtol=1e-10)
+
+
+def test_equilibria_supercritical_has_three_points():
+    system = LorenzSystem()  # rho = 28 > 1
+    eq = stability.equilibrium_points(system)
+    assert len(eq) == 3
+    np.testing.assert_allclose(eq[0], [0.0, 0.0, 0.0])
+
+
+def test_equilibria_subcritical_has_origin_only():
+    system = LorenzSystem(LorenzParameters(sigma=10.0, rho=0.5, beta=8.0 / 3.0))
+    assert len(stability.equilibrium_points(system)) == 1
+
+
+def test_lorenzsystem_methods_delegate_identically():
+    system = LorenzSystem()
+    state = np.array([2.0, 3.0, 4.0])
+    np.testing.assert_array_equal(system.jacobian(state), stability.jacobian(system, state))
+    eqs_method = system.equilibrium_points()
+    eqs_func = stability.equilibrium_points(system)
+    for a, b in zip(eqs_method, eqs_func):
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.slow
+def test_lyapunov_largest_exponent_positive_for_chaos():
+    system = LorenzSystem()
+    exps = stability.lyapunov_exponents(
+        system, InitialConditions(1.0, 1.0, 1.0), dt=0.01, num_steps=1000
+    )
+    assert len(exps) == 3
+    assert exps[0] > 0
+    assert exps[2] < 0
+    assert np.sum(exps) < 0

--- a/tests/test_analysis_sweeps.py
+++ b/tests/test_analysis_sweeps.py
@@ -28,8 +28,12 @@ def test_parameter_sweep_runs_one_sim_per_value_and_restores_params():
 def test_bifurcation_analysis_returns_expected_keys():
     sim = Simulator()
     out = sweeps.bifurcation_analysis(
-        sim, 'rho', (20.0, 28.0), num_points=3,
-        initial_conditions=InitialConditions(1.0, 1.0, 1.0), config=_small_config(),
+        sim,
+        'rho',
+        (20.0, 28.0),
+        num_points=3,
+        initial_conditions=InitialConditions(1.0, 1.0, 1.0),
+        config=_small_config(),
     )
     assert set(out) == {'parameter_values', 'attractors', 'parameter_name'}
     assert len(out['parameter_values']) == 3
@@ -39,7 +43,9 @@ def test_bifurcation_analysis_returns_expected_keys():
 def test_sensitivity_analysis_returns_three_divergences():
     sim = Simulator()
     out = sweeps.sensitivity_analysis(
-        sim, InitialConditions(1.0, 1.0, 1.0), perturbation=1e-8,
+        sim,
+        InitialConditions(1.0, 1.0, 1.0),
+        perturbation=1e-8,
         config=_small_config(),
     )
     assert set(out) >= {'original_trajectory', 'divergences', 'time', 'perturbation'}

--- a/tests/test_analysis_sweeps.py
+++ b/tests/test_analysis_sweeps.py
@@ -1,0 +1,55 @@
+"""Tests for analysis.sweeps (extracted from core.simulator)."""
+
+import numpy as np
+
+from lorenz_attractor.analysis import sweeps
+from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
+from lorenz_attractor.core.simulator import Simulator
+
+
+def _small_config():
+    return SimulationConfig(dt=0.01, num_steps=100)
+
+
+def test_parameter_sweep_runs_one_sim_per_value_and_restores_params():
+    sim = Simulator()
+    original_rho = sim.system.parameters.rho
+    values = np.array([20.0, 24.0, 28.0])
+    results = sweeps.parameter_sweep(
+        sim, 'rho', values, InitialConditions(1.0, 1.0, 1.0), _small_config()
+    )
+    assert len(results) == 3
+    # parameters restored after the sweep
+    assert sim.system.parameters.rho == original_rho
+    # each result used the corresponding rho
+    assert [r.parameters.rho for r in results] == [20.0, 24.0, 28.0]
+
+
+def test_bifurcation_analysis_returns_expected_keys():
+    sim = Simulator()
+    out = sweeps.bifurcation_analysis(
+        sim, 'rho', (20.0, 28.0), num_points=3,
+        initial_conditions=InitialConditions(1.0, 1.0, 1.0), config=_small_config(),
+    )
+    assert set(out) == {'parameter_values', 'attractors', 'parameter_name'}
+    assert len(out['parameter_values']) == 3
+    assert len(out['attractors']) == 3
+
+
+def test_sensitivity_analysis_returns_three_divergences():
+    sim = Simulator()
+    out = sweeps.sensitivity_analysis(
+        sim, InitialConditions(1.0, 1.0, 1.0), perturbation=1e-8,
+        config=_small_config(),
+    )
+    assert set(out) >= {'original_trajectory', 'divergences', 'time', 'perturbation'}
+    assert len(out['divergences']) == 3
+
+
+def test_simulator_methods_delegate():
+    sim = Simulator()
+    values = np.array([24.0, 28.0])
+    via_method = sim.parameter_sweep(
+        'rho', values, InitialConditions(1.0, 1.0, 1.0), _small_config()
+    )
+    assert len(via_method) == 2

--- a/tests/test_backcompat_api.py
+++ b/tests/test_backcompat_api.py
@@ -22,8 +22,13 @@ def test_top_level_exports_present():
 
 def test_analysis_namespace_exposes_all_functions():
     for fn in (
-        jacobian, equilibrium_points, lyapunov_exponents, poincare_section,
-        parameter_sweep, bifurcation_analysis, sensitivity_analysis,
+        jacobian,
+        equilibrium_points,
+        lyapunov_exponents,
+        poincare_section,
+        parameter_sweep,
+        bifurcation_analysis,
+        sensitivity_analysis,
     ):
         assert callable(fn)
 

--- a/tests/test_backcompat_api.py
+++ b/tests/test_backcompat_api.py
@@ -1,0 +1,35 @@
+"""Lock the public API: old call sites keep working after the analysis extraction."""
+
+import numpy as np
+
+import lorenz_attractor as la
+from lorenz_attractor.analysis import (
+    bifurcation_analysis,
+    equilibrium_points,
+    jacobian,
+    lyapunov_exponents,
+    parameter_sweep,
+    poincare_section,
+    sensitivity_analysis,
+)
+from lorenz_attractor.core.lorenz import LorenzSystem
+
+
+def test_top_level_exports_present():
+    for name in ("LorenzSystem", "Simulator", "LorenzPlotter", "DataExporter"):
+        assert hasattr(la, name)
+
+
+def test_analysis_namespace_exposes_all_functions():
+    for fn in (
+        jacobian, equilibrium_points, lyapunov_exponents, poincare_section,
+        parameter_sweep, bifurcation_analysis, sensitivity_analysis,
+    ):
+        assert callable(fn)
+
+
+def test_legacy_methods_still_work():
+    system = LorenzSystem()
+    state = np.array([1.0, 1.0, 1.0])
+    np.testing.assert_array_equal(system.jacobian(state), jacobian(system, state))
+    assert len(system.equilibrium_points()) == 3

--- a/tests/test_export_data.py
+++ b/tests/test_export_data.py
@@ -1,0 +1,65 @@
+"""Round-trip and format tests for DataExporter."""
+
+import json
+
+import numpy as np
+import pytest
+
+from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
+from lorenz_attractor.core.simulator import Simulator
+from lorenz_attractor.export.data import HAS_HDF5, DataExporter
+
+
+@pytest.fixture
+def result():
+    sim = Simulator()
+    return sim.simulate(
+        InitialConditions(1.0, 1.0, 1.0), SimulationConfig(dt=0.01, num_steps=100)
+    )
+
+
+def test_export_csv_without_metadata_is_readable(result, tmp_path):
+    path = tmp_path / 'out.csv'
+    DataExporter().export_csv(result, str(path), include_metadata=False)
+    text = path.read_text()
+    assert text.splitlines()[0] == 'time,x,y,z'
+    assert len(text.splitlines()) == 1 + len(result.time)
+
+
+def test_export_json_roundtrips_trajectory(result, tmp_path):
+    path = tmp_path / 'out.json'
+    DataExporter().export_json(result, str(path))
+    data = json.loads(path.read_text())
+    assert data['parameters']['sigma'] == result.parameters.sigma
+    traj = np.array(data['data']['trajectory'])
+    np.testing.assert_allclose(traj, result.trajectory)
+
+
+def test_export_numpy_roundtrips_via_simulationresult_load(result, tmp_path):
+    from lorenz_attractor.core.simulator import SimulationResult
+
+    path = tmp_path / 'out.npz'
+    DataExporter().export_numpy(result, str(path))
+    loaded = SimulationResult.load(str(path))
+    np.testing.assert_allclose(loaded.trajectory, result.trajectory)
+
+
+def test_export_matlab_writes_file(result, tmp_path):
+    from scipy.io import loadmat
+
+    path = tmp_path / 'out.mat'
+    DataExporter().export_matlab(result, str(path))
+    mat = loadmat(str(path))
+    np.testing.assert_allclose(mat['trajectory'], result.trajectory)
+
+
+@pytest.mark.skipif(not HAS_HDF5, reason='h5py not installed')
+def test_export_hdf5_roundtrips_trajectory(result, tmp_path):
+    import h5py
+
+    path = tmp_path / 'out.h5'
+    DataExporter().export_hdf5(result, str(path))
+    with h5py.File(str(path), 'r') as f:
+        assert 'data' in f
+        assert 'trajectory' in f['data']
+        np.testing.assert_allclose(f['data']['trajectory'][...], result.trajectory)

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -1,0 +1,52 @@
+"""Numerical sanity tests for the integrators on dy/dt = -y (y(t)=e^-t)."""
+
+import numpy as np
+import pytest
+
+from lorenz_attractor.integration.integrators import (
+    AdaptiveIntegrator,
+    DormandPrince54Integrator,
+    EulerIntegrator,
+    RungeKutta4Integrator,
+)
+
+
+def _decay(y, t):
+    return -y
+
+
+def test_rk4_more_accurate_than_euler():
+    y0 = np.array([1.0])
+    t_span = (0.0, 1.0)
+    _, y_euler = EulerIntegrator(0.1).integrate(_decay, y0, t_span, num_steps=100)
+    _, y_rk4 = RungeKutta4Integrator(0.1).integrate(_decay, y0, t_span, num_steps=100)
+    exact = np.exp(-1.0)
+    err_euler = abs(y_euler[-1, 0] - exact)
+    err_rk4 = abs(y_rk4[-1, 0] - exact)
+    assert err_rk4 < err_euler
+
+
+def test_rk4_error_shrinks_with_smaller_dt():
+    y0 = np.array([1.0])
+    t_span = (0.0, 1.0)
+    exact = np.exp(-1.0)
+    _, y_coarse = RungeKutta4Integrator(0.1).integrate(_decay, y0, t_span, num_steps=10)
+    _, y_fine = RungeKutta4Integrator(0.1).integrate(_decay, y0, t_span, num_steps=100)
+    assert abs(y_fine[-1, 0] - exact) < abs(y_coarse[-1, 0] - exact)
+
+
+@pytest.mark.parametrize(
+    'integrator', [RungeKutta4Integrator, AdaptiveIntegrator, DormandPrince54Integrator]
+)
+def test_integrators_agree_on_decay(integrator):
+    y0 = np.array([1.0])
+    t_span = (0.0, 1.0)
+    _, y = integrator(0.05).integrate(_decay, y0, t_span, num_steps=200)
+    assert abs(y[-1, 0] - np.exp(-1.0)) < 1e-2
+
+
+def test_integrate_returns_consistent_shapes():
+    y0 = np.array([1.0, 2.0, 3.0])
+    t, y = RungeKutta4Integrator(0.01).integrate(_decay, y0, (0.0, 1.0), num_steps=50)
+    assert t.shape[0] == 51
+    assert y.shape == (51, 3)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -162,11 +162,11 @@ class TestSimulationConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = SimulationConfig(
-            dt=0.001, num_steps=50000, integration_method="rk45", save_interval=10
+            dt=0.001, num_steps=50000, integration_method="adaptive", save_interval=10
         )
         assert config.dt == 0.001
         assert config.num_steps == 50000
-        assert config.integration_method == "rk45"
+        assert config.integration_method == "adaptive"
         assert config.save_interval == 10
 
     def test_config_validation(self):
@@ -199,14 +199,14 @@ class TestSimulationConfig:
     def test_to_dict(self):
         """Test conversion to dictionary."""
         config = SimulationConfig(
-            dt=0.001, num_steps=50000, integration_method="rk45", save_interval=10
+            dt=0.001, num_steps=50000, integration_method="adaptive", save_interval=10
         )
         data = config.to_dict()
 
         expected = {
             'dt': 0.001,
             'num_steps': 50000,
-            'integration_method': 'rk45',
+            'integration_method': 'adaptive',
             'save_interval': 10,
         }
         assert data == expected
@@ -216,12 +216,24 @@ class TestSimulationConfig:
         data = {
             'dt': 0.001,
             'num_steps': 50000,
-            'integration_method': 'rk45',
+            'integration_method': 'adaptive',
             'save_interval': 10,
         }
         config = SimulationConfig.from_dict(data)
 
         assert config.dt == 0.001
         assert config.num_steps == 50000
-        assert config.integration_method == "rk45"
+        assert config.integration_method == "adaptive"
         assert config.save_interval == 10
+
+
+def test_adaptive_is_a_valid_integration_method():
+    # 'adaptive' is offered by the CLI and web UI and must validate.
+    config = SimulationConfig(integration_method='adaptive')
+    assert config.integration_method == 'adaptive'
+
+
+def test_rk45_is_not_a_valid_integration_method():
+    # 'rk45' is not implemented by the simulator and must be rejected.
+    with pytest.raises(ValueError):
+        SimulationConfig(integration_method='rk45')

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -235,5 +235,5 @@ def test_adaptive_is_a_valid_integration_method():
 
 def test_rk45_is_not_a_valid_integration_method():
     # 'rk45' is not implemented by the simulator and must be rejected.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='integration_method must be one of'):
         SimulationConfig(integration_method='rk45')

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,16 @@
+"""Tests for the Simulator orchestration layer."""
+
+import pytest
+
+from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
+from lorenz_attractor.core.simulator import Simulator
+
+
+@pytest.mark.parametrize('method', ['euler', 'rk4', 'adaptive', 'dopri5'])
+def test_all_advertised_methods_run_end_to_end(method):
+    sim = Simulator()
+    ic = InitialConditions(1.0, 1.0, 1.0)
+    config = SimulationConfig(dt=0.01, num_steps=50, integration_method=method)
+    result = sim.simulate(ic, config)
+    assert result.trajectory.shape[1] == 3
+    assert result.trajectory.shape[0] > 0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,5 +1,6 @@
 """Tests for the Simulator orchestration layer."""
 
+import numpy as np
 import pytest
 
 from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
@@ -14,3 +15,4 @@ def test_all_advertised_methods_run_end_to_end(method):
     result = sim.simulate(ic, config)
     assert result.trajectory.shape[1] == 3
     assert result.trajectory.shape[0] > 0
+    assert np.all(np.isfinite(result.trajectory))

--- a/tests/test_visualization_plotter.py
+++ b/tests/test_visualization_plotter.py
@@ -1,16 +1,17 @@
 """Headless smoke tests for plotting and image export."""
 
+import pytest
+
+from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
+from lorenz_attractor.core.simulator import Simulator
+from lorenz_attractor.export.image import ImageExporter
+from lorenz_attractor.visualization.plotter import LorenzPlotter
+
 import matplotlib
 
 matplotlib.use('Agg')  # must precede pyplot import anywhere downstream
 
 import matplotlib.pyplot as plt  # noqa: E402
-import pytest  # noqa: E402
-
-from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig  # noqa: E402
-from lorenz_attractor.core.simulator import Simulator  # noqa: E402
-from lorenz_attractor.export.image import ImageExporter  # noqa: E402
-from lorenz_attractor.visualization.plotter import LorenzPlotter  # noqa: E402
 
 
 @pytest.fixture
@@ -21,12 +22,14 @@ def result():
 
 
 def test_plotter_constructs():
-    assert LorenzPlotter(style='dark') is not None
+    plotter = LorenzPlotter(style='dark', dpi=150)
+    assert plotter.style == 'dark'
+    assert plotter.dpi == 150
 
 
 def test_plot_3d_trajectory_builds_a_figure(result):
     fig = LorenzPlotter().plot_3d_trajectory(result)
-    assert fig is not None
+    assert hasattr(fig, 'axes') and len(fig.axes) > 0
     plt.close(fig)
 
 

--- a/tests/test_visualization_plotter.py
+++ b/tests/test_visualization_plotter.py
@@ -1,13 +1,12 @@
 """Headless smoke tests for plotting and image export."""
 
+import matplotlib
 import pytest
 
 from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig
 from lorenz_attractor.core.simulator import Simulator
 from lorenz_attractor.export.image import ImageExporter
 from lorenz_attractor.visualization.plotter import LorenzPlotter
-
-import matplotlib
 
 matplotlib.use('Agg')  # must precede pyplot import anywhere downstream
 

--- a/tests/test_visualization_plotter.py
+++ b/tests/test_visualization_plotter.py
@@ -1,0 +1,40 @@
+"""Headless smoke tests for plotting and image export."""
+
+import matplotlib
+
+matplotlib.use('Agg')  # must precede pyplot import anywhere downstream
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+from lorenz_attractor.core.parameters import InitialConditions, SimulationConfig  # noqa: E402
+from lorenz_attractor.core.simulator import Simulator  # noqa: E402
+from lorenz_attractor.export.image import ImageExporter  # noqa: E402
+from lorenz_attractor.visualization.plotter import LorenzPlotter  # noqa: E402
+
+
+@pytest.fixture
+def result():
+    return Simulator().simulate(
+        InitialConditions(1.0, 1.0, 1.0), SimulationConfig(dt=0.01, num_steps=200)
+    )
+
+
+def test_plotter_constructs():
+    assert LorenzPlotter(style='dark') is not None
+
+
+def test_plot_3d_trajectory_builds_a_figure(result):
+    fig = LorenzPlotter().plot_3d_trajectory(result)
+    assert fig is not None
+    plt.close(fig)
+
+
+def test_image_exporter_writes_files(result, tmp_path):
+    exporter = ImageExporter(dpi=72)
+    p3d = tmp_path / 'traj3d.png'
+    p2d = tmp_path / 'proj2d.png'
+    exporter.export_3d_plot(result, str(p3d))
+    exporter.export_2d_projections(result, str(p2d))
+    assert p3d.exists() and p3d.stat().st_size > 0
+    assert p2d.exists() and p2d.stat().st_size > 0

--- a/tests/test_visualization_realtime.py
+++ b/tests/test_visualization_realtime.py
@@ -12,9 +12,11 @@ from lorenz_attractor.core.simulator import Simulator
 def _mock_graphics_libs():
     mods = {
         name: mock.MagicMock()
-        for name in ("pygame", "OpenGL", "OpenGL.GL", "OpenGL.GLU", "moderngl")
+        for name in ('pygame', 'OpenGL', 'OpenGL.GL', 'OpenGL.GLU', 'moderngl')
     }
     with mock.patch.dict(sys.modules, mods):
+        for cached in ('lorenz_attractor.visualization.realtime',):
+            sys.modules.pop(cached, None)
         yield
 
 
@@ -22,11 +24,13 @@ def test_realtime_visualizer_constructs():
     from lorenz_attractor.visualization.realtime import RealtimeVisualizer
 
     viz = RealtimeVisualizer(Simulator(), trail_length=100)
-    assert viz is not None
+    assert isinstance(viz, RealtimeVisualizer)
+    assert viz.trail_length == 100
 
 
 def test_streaming_visualizer_constructs():
     from lorenz_attractor.visualization.realtime import StreamingVisualizer
 
     viz = StreamingVisualizer(Simulator(), buffer_size=500)
-    assert viz is not None
+    assert isinstance(viz, StreamingVisualizer)
+    assert viz.buffer_size == 500

--- a/tests/test_visualization_realtime.py
+++ b/tests/test_visualization_realtime.py
@@ -1,0 +1,32 @@
+"""Construction smoke tests for realtime visualizers with GL/pygame mocked."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from lorenz_attractor.core.simulator import Simulator
+
+
+@pytest.fixture(autouse=True)
+def _mock_graphics_libs():
+    mods = {
+        name: mock.MagicMock()
+        for name in ("pygame", "OpenGL", "OpenGL.GL", "OpenGL.GLU", "moderngl")
+    }
+    with mock.patch.dict(sys.modules, mods):
+        yield
+
+
+def test_realtime_visualizer_constructs():
+    from lorenz_attractor.visualization.realtime import RealtimeVisualizer
+
+    viz = RealtimeVisualizer(Simulator(), trail_length=100)
+    assert viz is not None
+
+
+def test_streaming_visualizer_constructs():
+    from lorenz_attractor.visualization.realtime import StreamingVisualizer
+
+    viz = StreamingVisualizer(Simulator(), buffer_size=500)
+    assert viz is not None

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,15 @@
+"""Smoke tests for the Dash web app (no server started)."""
+
+import dash
+
+from lorenz_attractor.web.app import create_app
+
+
+def test_create_app_returns_dash_instance():
+    app = create_app()
+    assert isinstance(app, dash.Dash)
+
+
+def test_app_has_a_layout():
+    app = create_app()
+    assert app.layout is not None


### PR DESCRIPTION
## Phase 0 — Foundation (Polish & Honesty)

First phase of the roadmap to take this repo to the next level. Makes the package's structure and claims trustworthy and makes CI actually enforce quality, so later phases (scientific credibility, more chaotic systems, browser 3D, ML) build on solid ground. **No new end-user features.**

### Bug fixes (correctness)
- **Integration-method mismatch:** `SimulationConfig` accepted `rk45` (which the simulator can't run) and rejected `adaptive` (which the CLI/web offer). Aligned to the real set `euler, rk4, adaptive, dopri5`.
- **Adaptive integrators overshooting:** `AdaptiveIntegrator` & `DormandPrince54Integrator` mutated `self.dt` and integrated far past the target time, silently returning wrong results (e.g. `y≈1e-29` instead of `e⁻¹` at t=1). They now sub-cycle error-controlled steps within each fixed grid interval — verified correct (err ~1e-13).

### Structure & honesty
- Extracted the scattered analysis code from `core/` into a real `analysis/` package (`stability.py`, `sections.py`, `sweeps.py`) with **back-compat delegation** — no public API change (guarded by a same-result delegation/back-compat test). Removed the empty `utils/` stub.
- README honesty pass: softened the Lyapunov "accurate" claim (the method is a simplified Benettin estimator — rigorous re-orthogonalization is a Phase 1 item), corrected "parallel" → thread-based/GIL, marked perf numbers indicative, fixed the architecture tree.

### Tests
- Added tests for previously-untested modules: integrator convergence, export round-trips (CSV/JSON/HDF5/NumPy/MATLAB), plotting/image (headless), realtime/OpenGL (mocked smoke), web app (smoke), plus a back-compat API test. 55 → 88 tests.

### CI now genuinely gates (was red on `main`)
- **flake8: 27 → 0** and **mypy `--strict`: 173 → 0** across the whole codebase (all pre-existing debt cleared; behavior-preserving — annotations, not logic changes).
- Made `bandit` gate (justified pickle skips + targeted `# nosec`), replaced non-gating `safety` with gating `pip-audit`, added a `--cov-fail-under=39` coverage floor, removed a misleading `--exit-zero` flake8 step, bumped mypy `python_version` 3.8→3.10.

### Verification
All gates green locally in a CI-faithful env: `black` / `isort` / `flake8` (0) / `mypy --strict` (0, 23 files) / `bandit` / `pip-audit` / `pytest` (88 passed incl. slow, coverage 41.4% ≥ 39%). Reviewed task-by-task plus a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

### Known follow-ups (deferred, tracked)
- Phase 1: fix the Lyapunov exponent numerics (add tangent re-orthogonalization) — README already reflects the current limitation.
- Minor: dead `HighPerformanceRK4Integrator` (unwired) and tightening a `_stream_worker` except clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)